### PR TITLE
feat(analytics): add Umami self-hosted tracking

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -122,6 +122,15 @@ export default defineConfig({
             content: 'https://docs.sip-protocol.org/og-image.png',
           },
         },
+        // Umami Analytics (self-hosted, privacy-first)
+        {
+          tag: 'script',
+          attrs: {
+            defer: true,
+            src: 'https://analytics.sip-protocol.org/script.js',
+            'data-website-id': '5a56a99e-502d-499e-a282-c46a20e556e0',
+          },
+        },
       ],
     }),
   ],


### PR DESCRIPTION
## Summary

- Add Umami analytics to docs-sip (documentation site)
- Website ID: `5a56a99e-502d-499e-a282-c46a20e556e0`
- Self-hosted at analytics.sip-protocol.org

## Changes

- Added script tag to Starlight `head` config in astro.config.mjs

Closes #28

---

Generated with [Claude Code](https://claude.com/claude-code)