### PR TITLE
docs: update Zypherpunk hackathon winnings to $6,500 (3 tracks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Astro](https://img.shields.io/badge/Astro-5.6.1-BC52EE?logo=astro&logoColor=white)](https://astro.build)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**🏆 Winner — [Zypherpunk Hackathon](https://zypherpunk.xyz) NEAR Track ($4,000)**
+**🏆 Winner — [Zypherpunk Hackathon](https://zypherpunk.xyz) 3 Tracks ($6,500: NEAR $4,000 + Tachyon $500 + pumpfun $2,000)**
 
 Official documentation for **SIP Protocol** - the privacy layer for cross-chain transactions via NEAR Intents + Zcash.
 

--- a/src/content/docs/roadmap.md
+++ b/src/content/docs/roadmap.md
@@ -27,7 +27,7 @@ a16z's December 2025 thesis validates SIP's core positioning as privacy middlewa
 
 ### Achievement
 
-🏆 **Zypherpunk Hackathon NEAR Track Winner** ($4,000) — December 2025
+🏆 **Zypherpunk Hackathon Winner — 3 Tracks** ($6,500: NEAR $4,000 + Tachyon $500 + pumpfun $2,000) — December 2025
 
 ## Phases Overview
 


### PR DESCRIPTION
## Summary
- Update Zypherpunk Hackathon prize from $4,000 to **$6,500**
- Add pumpfun track ($2,000) + Tachyon ($500) to NEAR ($4,000)
- Total: 3 tracks won

## Files Changed
- README.md
- src/content/docs/roadmap.md

## Test plan
- [x] Documentation only, no code changes