### PR TITLE
fix(docker): install Playwright Chromium for rehype-mermaid SVG rendering (#89)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20-alpine AS builder
+FROM node:20-bookworm-slim AS builder
 
 WORKDIR /app
 
@@ -9,13 +9,19 @@ COPY package*.json ./
 # Install dependencies
 RUN npm ci
 
+# Install Playwright Chromium for rehype-mermaid (renders Mermaid diagrams to SVG at build time).
+# Required by 7 markdown files (architecture.md, concepts/{stealth-address,viewing-key}.md,
+# specs/{fulfillment-proof,funding-proof,validity-proof,zk-architecture}.md). Without this,
+# `npm run build` fails with "browserType.launch: Executable doesn't exist". See sip-protocol/docs-sip#89.
+RUN npx playwright install --with-deps chromium-headless-shell
+
 # Copy source
 COPY . .
 
 # Build Astro site
 RUN npm run build
 
-# Production stage - use nginx to serve static files
+# Production stage - use nginx to serve static files (only dist/ is copied, no Node runtime needed)
 FROM nginx:alpine
 
 # Copy built assets


### PR DESCRIPTION
## Summary

- Switches Dockerfile builder from `node:20-alpine` to `node:20-bookworm-slim` and installs Playwright Chromium before `npm run build`
- Unblocks `Deploy to VPS` workflow (failing on every `main` push since rehype-mermaid was wired in)
- Production runtime stage unchanged — still `nginx:alpine`, only `dist/` is copied

## Why

The `Deploy to VPS` workflow has been failing on every `main` push for ~7 weeks. The deployed `sip-docs` container is stuck on the 2026-02-28 image because every subsequent build dies in `npm run build` with:

> browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1200/chrome-headless-shell-linux64/chrome-headless-shell

7 markdown files (`architecture.md`, `concepts/{stealth-address,viewing-key}.md`, `specs/{fulfillment-proof,funding-proof,validity-proof,zk-architecture}.md`) need rehype-mermaid → Playwright Chromium to render Mermaid diagrams to SVG at build time. The same root cause was patched for the `Docs Validation` PR-CI workflow in #86 commit `b7d471e`, but the production Dockerfile was never touched.

`--with-deps` is Debian/Ubuntu-only, hence the move to `bookworm-slim` for the builder. Production stays on `nginx:alpine` (no Node runtime needed in the runtime stage), so the final image size is unchanged.

## Verification

Local `docker build -t docs-sip-test:fix89 .` (Colima, Mac):

- ✅ Builds end-to-end in 82s (1277 pages compiled, sitemap + Pagefind index generated)
- ✅ Container serves real Astro pages, not the homepage HTML:
  - `/intro/` → `<title>SIP Protocol Documentation | SIP Protocol</title>`
  - `/sipher/sentinel/overview/` → `<title>SENTINEL — External Surface Reference | SIP Protocol</title>`, `Source of truth` banner, `Last synced` line
- ✅ All 5 PR #86 SENTINEL mirror pages present in `/usr/share/nginx/html/sipher/sentinel/`

## Test plan

- [ ] PR CI (`Docs Validation`) green
- [ ] Post-merge `Deploy to VPS` workflow completes `success`
- [ ] Fresh `sip-docs` container deploys with new image SHA
- [ ] `https://docs.sip-protocol.org/intro/` renders the Astro intro page
- [ ] `https://docs.sip-protocol.org/sipher/sentinel/overview/` renders SENTINEL overview (banner + Mermaid SVG diagram)

## Notes

- Closes #89.
- The pre-existing nginx SPA `try_files ... /index.html` fallback (which masks 404s as the homepage with HTTP 200) is **not** addressed here — flagged as a separate follow-up in #89's "Pre-existing related symptom" section. Will file a follow-up issue if it persists after this lands.