### PR TITLE
fix(ci): point Deploy to VPS at ~/docs and harden script with set -euo pipefail

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -77,8 +77,9 @@ jobs:
           username: sip
           key: ${{ secrets.VPS_SSH_KEY }}
           script: |
-            cd ~/app
-            docker pull ghcr.io/sip-protocol/docs-sip:latest
+            set -euo pipefail
+            cd ~/docs
+            docker compose pull docs
             docker compose up -d docs
             docker image prune -f
 


### PR DESCRIPTION
## Summary

- `cd ~/app` → `cd ~/docs` (correct compose-file location for sip-docs on VPS)
- `docker pull ghcr.io/...` → `docker compose pull docs` (idiomatic; uses the image declared in the compose file)
- Add `set -euo pipefail` so any future silent failure aborts instead of pretending to succeed

## Why

While verifying #90 (Dockerfile + Chromium fix), the post-merge \`Deploy to VPS\` run \`25317140159\` reported \"success\" but production stayed stale. SSH'd to VPS and found that \`~/app/docker-compose.yml\` is the **sip-website** project (service: \`web\`), not the docs project. The sip-docs compose file lives at \`~/docs/docker-compose.yml\` (service: \`docs\`, container: \`sip-docs\`).

Deploy step output (run [\`25317140159\`](https://github.com/sip-protocol/docs-sip/actions/runs/25317140159)) confirms the silent failure:

\`\`\`
2026-05-04T11:49:34.866Z no such service: docs
2026-05-04T11:50:09.204Z Deleted Images:
\`\`\`

The script ran \`docker pull ghcr.io/...:latest\` (succeeded — image landed on host), then \`docker compose up -d docs\` (failed — wrong compose file), then \`docker image prune -f\` (succeeded). Since the script lacks \`set -e\`, the failed middle step didn't abort the script — and since \`prune\` was the last line, the script's exit code was 0 → SSH action reported \"success.\"

This means the container has been stuck on the same image for ~7 weeks even though every merge has been pushing fresh images to GHCR.

## Verification

After this PR's logic was applied manually on the VPS (\`cd ~/docs && docker compose pull docs && docker compose up -d docs\`):

- Container restarted with fresh image \`sha256:9f487c5...\` (vs old \`cf28ff832543\`)
- All 5 PR #86 SENTINEL mirror pages render (\`overview\`, \`rest-api\`, \`tools\`, \`config\`, \`audit-log\`)
- Mermaid SVG renders on \`/architecture/\`, \`/specs/zk-architecture/\`, \`/concepts/{stealth-address,viewing-key}/\`, \`/specs/{funding-proof,validity-proof,fulfillment-proof}/\` (all 7 previously-failing files)

## Notes

- Pairs with #90 — Dockerfile fix solves the build-time half of \"deploys broken,\" this fix solves the deploy-time half.
- Out of scope: \`deploy.yml\` (GitHub Pages publish) is failing for the same Chromium-missing reason as the original Dockerfile bug. That's a parallel publish path, not the production serve path. Will file a follow-up.

## Test plan

- [ ] PR CI green (n/a — workflow file change, no validators trigger)
- [ ] After merge, watch \`Deploy to VPS\` run on \`main\`. Verify deploy step logs show \`Container sip-docs Recreated/Started\`, **not** \`no such service: docs\`.
- [ ] Verify production picks up a fresh image SHA (e.g. flip a doc, push, observe the URL change).