### PR TITLE
fix(docs): correct SDK 0.9.0 code examples + clarify demo/production mode (audit 1/4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7920,6 +7920,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jayson/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/jayson/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",

--- a/src/content/docs/concepts/privacy-levels.md
+++ b/src/content/docs/concepts/privacy-levels.md
@@ -103,16 +103,27 @@ Solver view:
 
 Full privacy with selective disclosure for authorized auditors.
 
-```typescript
-const viewingKey = sip.generateViewingKey('/audit')
+COMPLIANT mode requires a viewing key. The `IntentBuilder` covers input/output/privacy, but the viewing key is supplied through `createShieldedIntent` (the function the builder delegates to) via the `viewingKey` field of `CreateIntentParams`:
 
-const intent = await sip
-  .intent()
-  .input('solana', 'SOL', 5_000_000_000n)
-  .output('near', 'NEAR')
-  .privacy(PrivacyLevel.COMPLIANT)
-  .viewingKey(viewingKey)
-  .build()
+```typescript
+import { createShieldedIntent, generateViewingKey, PrivacyLevel } from '@sip-protocol/sdk'
+
+const viewingKey = generateViewingKey('m/0/audit')
+
+const intent = await createShieldedIntent({
+  input: {
+    asset: { chain: 'solana', symbol: 'SOL', address: null, decimals: 9 },
+    amount: 5_000_000_000n,
+  },
+  output: {
+    asset: { chain: 'near', symbol: 'NEAR', address: null, decimals: 24 },
+    minAmount: 0n,
+    maxSlippage: 0.01,
+  },
+  privacy: PrivacyLevel.COMPLIANT,
+  recipientMetaAddress,
+  viewingKey: viewingKey.key,
+})
 ```
 
 ### Visibility
@@ -186,30 +197,44 @@ Once data is committed/hidden, it cannot be revealed without user cooperation.
 
 ## SDK Usage
 
-```typescript
-import { SIP, PrivacyLevel } from '@sip-protocol/sdk'
+`createShieldedIntent` accepts a `CreateIntentParams` object: `{ input, output, privacy, recipientMetaAddress?, viewingKey?, ttl? }`. `input`/`output` carry the asset and amount; the privacy level is set via `privacy`.
 
-const sip = new SIP({ network: 'testnet' })
+```typescript
+import { createShieldedIntent, generateViewingKey, PrivacyLevel } from '@sip-protocol/sdk'
+
+const input = {
+  asset: { chain: 'near', symbol: 'NEAR', address: null, decimals: 24 },
+  amount: 100n,
+}
+const output = {
+  asset: { chain: 'ethereum', symbol: 'ETH', address: null, decimals: 18 },
+  minAmount: 0n,
+  maxSlippage: 0.01,
+}
 
 // Transparent
-const transparent = await sip.createIntent({
-  privacyLevel: PrivacyLevel.TRANSPARENT,
-  sender: '0x...',
-  recipient: '0x...',
-  inputAmount: 100n,
+const transparent = await createShieldedIntent({
+  input,
+  output,
+  privacy: PrivacyLevel.TRANSPARENT,
 })
 
 // Shielded - SDK generates commitments, stealth, proofs
-const shielded = await sip.createIntent({
-  privacyLevel: PrivacyLevel.SHIELDED,
-  inputAmount: 100n,
+const shielded = await createShieldedIntent({
+  input,
+  output,
+  privacy: PrivacyLevel.SHIELDED,
+  recipientMetaAddress,
 })
 
 // Compliant - SDK adds encrypted viewing data
-const compliant = await sip.createIntent({
-  privacyLevel: PrivacyLevel.COMPLIANT,
-  inputAmount: 100n,
-  auditorKeyHash: '0x...',
+const viewingKey = generateViewingKey('m/0/audit')
+const compliant = await createShieldedIntent({
+  input,
+  output,
+  privacy: PrivacyLevel.COMPLIANT,
+  recipientMetaAddress,
+  viewingKey: viewingKey.key,
 })
 ```
 

--- a/src/content/docs/concepts/stealth-address.md
+++ b/src/content/docs/concepts/stealth-address.md
@@ -124,12 +124,13 @@ const isMine = checkStealthAddress(
 
 if (isMine) {
   // Derive private key to claim funds
-  const privateKey = deriveStealthPrivateKey(
+  // (the ephemeral public key is read from stealthAddress.ephemeralPublicKey internally)
+  const recovery = deriveStealthPrivateKey(
     stealthAddress,
-    ephemeralPublicKey,
     spendingPrivateKey,
     viewingPrivateKey
   )
+  // recovery.privateKey is the spendable key for stealthAddress
 }
 ```
 
@@ -281,13 +282,12 @@ const isMine = checkStealthAddress(
 
 // Recipient claims
 if (isMine) {
-  const pk = deriveStealthPrivateKey(
+  const recovery = deriveStealthPrivateKey(
     stealthAddress,
-    ephemeralPublicKey,
     meta.spendingPrivateKey,
     meta.viewingPrivateKey
   )
-  // Use pk to spend from stealthAddress
+  // Use recovery.privateKey to spend from stealthAddress
 }
 ```
 
@@ -307,9 +307,9 @@ SIP supports multiple elliptic curves to enable stealth addresses across differe
 const ethMeta = generateStealthMetaAddress('ethereum')
 const btcMeta = generateStealthMetaAddress('bitcoin')
 
-// ed25519 - for Solana, NEAR
-const solMeta = generateStealthMetaAddress('solana', { curve: 'ed25519' })
-const nearMeta = generateStealthMetaAddress('near', { curve: 'ed25519' })
+// ed25519 - for Solana, NEAR (curve is auto-selected from the chain)
+const solMeta = generateStealthMetaAddress('solana')
+const nearMeta = generateStealthMetaAddress('near')
 ```
 
 ### Curve Differences

--- a/src/content/docs/concepts/viewing-key.md
+++ b/src/content/docs/concepts/viewing-key.md
@@ -116,11 +116,12 @@ Reveals ONLY the specific transaction.
 ```typescript
 import { encryptForViewing, decryptWithViewing } from '@sip-protocol/sdk'
 
+// TransactionData = { sender: string, recipient: string, amount: string, timestamp: number }
 const txData = {
   sender: '0xabc...',
   recipient: '0xdef...',
-  amount: 1000n,
-  asset: 'ETH'
+  amount: '1000',
+  timestamp: Date.now(),
 }
 
 // Encrypt for viewing key holder
@@ -132,14 +133,13 @@ const decrypted = decryptWithViewing(encrypted, viewingKey)
 
 ### Multi-Key Encryption
 
-Encrypt for multiple authorized viewers:
+`encryptForViewing` encrypts for a single `ViewingKey`. To grant access to multiple authorized viewers, encrypt the data once per key — each holder can then decrypt their own blob independently:
 
 ```typescript
-const encrypted = encryptForViewing(txData, [
-  auditorKey,
-  complianceKey,
-  taxKey
-])
+const viewers = [auditorKey, complianceKey, taxKey]
+
+const encryptedBlobs = viewers.map((key) => encryptForViewing(txData, key))
+// encryptedBlobs[0] decrypts with auditorKey, [1] with complianceKey, etc.
 ```
 
 Each key holder can decrypt independently.
@@ -150,25 +150,30 @@ A ViewingProof demonstrates that decrypted data is authentic without revealing t
 
 ```typescript
 interface ViewingProof {
-  intentHash: string
-  revealedData: TransactionData
-  commitmentProof: {
-    inputAmountProof: ZKProof
-    outputAmountProof: ZKProof
+  /** The decrypted transaction details */
+  transaction: {
+    sender: string
+    recipient: string
+    amount: string
+    timestamp: number
   }
-  viewingKeyHash: string
-  proofTimestamp: number
+  /** Proof that decryption was done correctly */
+  proof: ZKProof
 }
 ```
 
 Verifier checks:
 1. ZK proof is valid
 2. Revealed amounts match on-chain commitments
-3. Viewing key hash matches authorized viewer
+3. The proof corresponds to the authorized viewer's key
 
 ## Access Control
 
-### Key Registration
+:::note[Conceptual / roadmap]
+The grant and revocation APIs below are conceptual — they describe a planned compliance-module capability, not shipped top-level SDK exports. The current SDK does not export `ViewingKeyGrant` or a `revokeViewingKey` function. Access control today is enforced operationally: hierarchical key derivation (`deriveViewingKey`) limits scope (per-transaction TVKs reveal only one tx), and a key is "revoked" by ceasing to share it and rotating the parent. Granular, on-chain grant tracking is expected to live in the compliance module (`ComplianceManager`).
+:::
+
+### Key Registration (conceptual)
 
 ```typescript
 interface ViewingKeyGrant {
@@ -185,11 +190,12 @@ interface ViewingKeyGrant {
 }
 ```
 
-### Revocation
+### Revocation (conceptual)
 
 Keys can be revoked but previously-viewed data cannot be "un-revealed":
 
 ```typescript
+// Planned compliance-module API (not a shipped SDK export)
 await revokeViewingKey(grantId)
 ```
 
@@ -289,19 +295,19 @@ const auditKey = deriveViewingKey(masterKey, '/audit/2024')
 const taxKey = deriveViewingKey(masterKey, '/tax/quarterly')
 
 // Encrypt transaction for auditor
+// TransactionData = { sender: string, recipient: string, amount: string, timestamp: number }
 const txData = {
-  intentHash: '0x123...',
-  inputAmount: 1000n,
-  outputAmount: 950n,
   sender: '0xabc...',
-  recipient: '0xdef...'
+  recipient: '0xdef...',
+  amount: '1000',
+  timestamp: Date.now(),
 }
 
 const encrypted = encryptForViewing(txData, auditKey)
 
 // Auditor decrypts
 const revealed = decryptWithViewing(encrypted, auditKey)
-console.log(revealed.inputAmount) // 1000n
+console.log(revealed.amount) // "1000"
 ```
 
 ## Trust Model

--- a/src/content/docs/cookbook/01-basic-swap.mdx
+++ b/src/content/docs/cookbook/01-basic-swap.mdx
@@ -170,18 +170,18 @@ basicSwap()
 
 ### Pitfall 1: Forgetting to Generate Stealth Keys
 
-**Problem:** Calling `.recipient()` without generating keys first.
+**Problem:** Building a shielded intent without setting a recipient.
 
 ```typescript
-// ❌ Wrong - no stealth keys generated
+// ❌ Wrong - no recipient set
 const intent = await sip.intent()
   .input('solana', 'SOL', 1_000_000_000n)
   .output('zcash', 'ZEC', 50_000_000n)
   .privacy(PrivacyLevel.SHIELDED)
-  .build()  // Error: No recipient for shielded mode
+  .build()  // Builds with a placeholder recipient - real recipient enforced at production getQuotes
 ```
 
-**Solution:** Always generate keys before using shielded mode.
+**Solution:** Always generate keys and set a recipient before using shielded mode.
 
 ```typescript
 // ✅ Correct
@@ -201,8 +201,8 @@ const intent = await sip.intent()
 **Problem:** Passing decimal numbers instead of smallest unit bigints.
 
 ```typescript
-// ❌ Wrong - using decimal SOL
-.input('solana', 'SOL', 1.5)  // Will floor to 1 lamport!
+// ❌ Wrong - the number path always multiplies by 1e18, ignoring token decimals
+.input('solana', 'SOL', 1.5)  // Becomes 1.5 * 1e18, not 1.5 SOL (9 decimals) - off by 1e9
 ```
 
 **Solution:** Always use the smallest unit (lamports, zatoshis, wei, etc.) as bigint.

--- a/src/content/docs/cookbook/02-privacy-levels.mdx
+++ b/src/content/docs/cookbook/02-privacy-levels.mdx
@@ -42,9 +42,9 @@ const transparentIntent = await sip.intent()
 console.log('Privacy level:', transparentIntent.privacyLevel)
 // Output: "transparent"
 
-// No stealth address needed for transparent mode
-console.log('Has stealth address:', !!transparentIntent.recipientStealth)
-// Output: false (placeholder only)
+// No real stealth address in transparent mode - a placeholder is used
+console.log('Is placeholder stealth:', transparentIntent.recipientStealth.address === '0x0')
+// Output: true (placeholder address '0x0', not a real stealth address)
 
 // Execute and get public transaction hash
 const quotes = await sip.getQuotes(transparentIntent)
@@ -96,9 +96,17 @@ console.log('Transaction hash:', result.txHash)
 
 ### Step 3: Compliant Mode (Privacy + Audit)
 
-Use compliant mode when you need privacy but also audit capability:
+Use compliant mode when you need privacy but also audit capability.
+
+:::note[Compliant mode needs `createShieldedIntent`]
+The fluent `sip.intent()` builder has no viewing-key setter, and building a `COMPLIANT`
+intent without a viewing key throws (`viewingKey is required for compliant mode`). Use
+`createShieldedIntent` directly so you can pass `viewingKey` at creation time.
+:::
 
 ```typescript
+import { createShieldedIntent } from '@sip-protocol/sdk'
+
 // Generate viewing key for auditors
 const viewingKey = sip.generateViewingKey('/m/44/501/0/compliance')
 
@@ -112,19 +120,7 @@ console.log('Viewing key:', {
 sip.generateStealthKeys('near', 'compliant-wallet')
 const recipientAddress = sip.getStealthAddress()!
 
-// Compliant swap - private but auditable
-const compliantIntent = await sip.intent()
-  .input('solana', 'SOL', 1_000_000_000n)
-  .output('near', 'NEAR', 100_000_000n)
-  .privacy(PrivacyLevel.COMPLIANT)
-  .recipient(recipientAddress)
-  .slippage(1)
-  .build()
-
-// But wait - we need to pass the viewing key during creation!
-// Use createShieldedIntent directly for more control:
-import { createShieldedIntent } from '@sip-protocol/sdk'
-
+// Compliant swap - private but auditable (viewing key passed at creation)
 const compliantIntentWithKey = await createShieldedIntent({
   input: {
     asset: { chain: 'solana', symbol: 'SOL', address: null, decimals: 9 },
@@ -251,21 +247,22 @@ const intent = await sip.intent()
   .build()
 ```
 
-### Pitfall 2: Using Compliant Mode Without Viewing Key
+### Pitfall 2: Building Compliant Mode with the Fluent Builder
 
-**Problem:** Setting privacy to COMPLIANT but not providing a viewing key.
+**Problem:** Trying to create a COMPLIANT intent through `sip.intent()`. The builder has
+no viewing-key setter, and building COMPLIANT without one throws.
 
 ```typescript
-// ❌ Wrong - compliant mode requires viewing key
+// ❌ Wrong - the builder cannot attach a viewing key, so this throws
 const intent = await sip.intent()
   .privacy(PrivacyLevel.COMPLIANT)
-  .build()  // Error: viewingKey required for compliant mode
+  .build()  // Error: viewingKey is required for compliant mode
 ```
 
-**Solution:** Generate and provide viewing key for compliant mode.
+**Solution:** Use `createShieldedIntent` so you can pass the viewing key at creation.
 
 ```typescript
-// ✅ Correct
+// ✅ Correct - createShieldedIntent accepts viewingKey
 const viewingKey = sip.generateViewingKey()
 const intent = await createShieldedIntent({
   // ... other params

--- a/src/content/docs/cookbook/03-viewing-keys.mdx
+++ b/src/content/docs/cookbook/03-viewing-keys.mdx
@@ -320,23 +320,26 @@ app.post('/api/get-viewing-key', authenticate, (req, res) => {
 const viewingKey = await fetch('/api/get-viewing-key').then(r => r.json())
 ```
 
-### Pitfall 4: Not Verifying Viewing Key Hash
+### Pitfall 4: Redundantly Pre-Checking the Viewing Key Hash
 
-**Problem:** Attempting decryption without checking hash first.
+**Good news:** `decryptWithViewing` already compares `viewingKeyHash` before doing any
+cipher work and throws a `CryptoError` on mismatch - so a wrong key fails fast, not
+"after expensive crypto operations." A `try/catch` around the call is sufficient.
 
 ```typescript
-// ❌ Wrong - expensive decryption attempt with wrong key
+// ✅ Fine - the SDK short-circuits on hash mismatch internally
 try {
-  const data = decryptWithViewing(encrypted, wrongKey)
+  const data = decryptWithViewing(encrypted, myKey)
 } catch (error) {
-  // Failed after expensive crypto operations
+  console.log('Wrong key or tampered data - decryption rejected')
 }
 ```
 
-**Solution:** Check viewing key hash before attempting decryption.
+**Optional:** If you want to branch without throwing (e.g. scanning many keys), you can
+still pre-check the hash yourself - this is a convenience, not a performance requirement.
 
 ```typescript
-// ✅ Correct - check hash first (cheap operation)
+// ✅ Optional - explicit branch instead of try/catch
 if (encrypted.viewingKeyHash !== myKey.hash) {
   console.log('Wrong key - skipping decryption')
 } else {

--- a/src/content/docs/cookbook/05-stealth-scanning.mdx
+++ b/src/content/docs/cookbook/05-stealth-scanning.mdx
@@ -342,7 +342,7 @@ class StealthWallet {
 }
 
 // Example usage
-async function demonstrateStealth Scanner() {
+async function demonstrateStealthScanner() {
   // Create wallet
   const wallet = new StealthWallet('ethereum', 'my-wallet')
   console.log('Receiving address:', wallet.getReceivingAddress())
@@ -369,7 +369,7 @@ async function demonstrateStealth Scanner() {
   console.log(`\nFinal balance: ${wallet.getBalance()}`)
 }
 
-demonstrateStealth Scanner()
+demonstrateStealthScanner()
 ```
 
 ## Common Pitfalls
@@ -424,7 +424,7 @@ for (const addr of allAddresses) {
 ```typescript
 // ❌ Wrong - scanning from genesis every time
 async function scan() {
-  const addresses = await getStealthAddresses FromBlock(0)
+  const addresses = await getStealthAddressesFromBlock(0)
   // Scans everything every time
 }
 ```

--- a/src/content/docs/cookbook/07-batch-transactions.mdx
+++ b/src/content/docs/cookbook/07-batch-transactions.mdx
@@ -474,7 +474,7 @@ demonstrateBatchProcessing()
 
 ```typescript
 // ❌ Wrong - all at once, may overwhelm
-await Promise.all(many Swaps.map(swap => execute(swap)))
+await Promise.all(manySwaps.map(swap => execute(swap)))
 ```
 
 ```typescript
@@ -532,7 +532,7 @@ await executeWithRetry(() => execute(swap), {
 
 ```typescript
 // ❌ Wrong - blast API with requests
-await Promise.all(1000s.map(s => getQuote(s)))
+await Promise.all(requests.map(s => getQuote(s)))
 ```
 
 ```typescript

--- a/src/content/docs/cookbook/08-error-handling.mdx
+++ b/src/content/docs/cookbook/08-error-handling.mdx
@@ -36,7 +36,7 @@ try {
   if (error instanceof ValidationError) {
     console.error('Validation failed:', error.message)
     console.error('Field:', error.field)
-    console.error('Details:', error.details)
+    console.error('Context:', error.context)
   }
 }
 
@@ -47,7 +47,7 @@ try {
   if (error instanceof CryptoError) {
     console.error('Crypto operation failed:', error.message)
     console.error('Code:', error.code)
-    console.error('Operation:', error.details?.operation)
+    console.error('Operation:', error.operation)
   }
 }
 
@@ -58,7 +58,7 @@ try {
   if (error instanceof IntentError) {
     console.error('Intent error:', error.message)
     console.error('Code:', error.code)
-    console.error('Intent ID:', error.details?.intentId)
+    console.error('Intent ID:', error.intentId)
   }
 }
 ```
@@ -150,8 +150,8 @@ async function executeWithRetry<T>(
 
       // Check if error is retryable
       const isRetryable =
-        error.code === 'NETWORK_ERROR' ||
-        error.code === 'TIMEOUT' ||
+        error.code === ErrorCode.NETWORK_FAILED ||
+        error.code === ErrorCode.NETWORK_TIMEOUT ||
         (retryableErrors.length > 0 && retryableErrors.includes(error.code))
 
       if (!isRetryable || attempt === maxRetries) {
@@ -192,7 +192,7 @@ const result = await executeWithRetry(
     maxRetries: 3,
     delayMs: 2000,
     backoffMultiplier: 1.5,
-    retryableErrors: [ErrorCode.NETWORK_ERROR],
+    retryableErrors: [ErrorCode.NETWORK_FAILED],
   },
   'execute'
 )
@@ -336,7 +336,7 @@ function determineRecovery(error: any): ErrorRecovery {
   }
 
   // Network error - retry with backoff
-  if (error.code === 'NETWORK_ERROR' || error.code === 'TIMEOUT') {
+  if (error.code === ErrorCode.NETWORK_FAILED || error.code === ErrorCode.NETWORK_TIMEOUT) {
     return {
       shouldRetry: true,
       delay: 2000,
@@ -344,11 +344,11 @@ function determineRecovery(error: any): ErrorRecovery {
     }
   }
 
-  // Insufficient balance - don't retry
-  if (error.code === ErrorCode.INSUFFICIENT_BALANCE) {
+  // Validation failure (e.g. insufficient balance) - don't retry
+  if (error.code === ErrorCode.VALIDATION_FAILED) {
     return {
       shouldRetry: false,
-      userMessage: 'Insufficient balance to complete this swap.',
+      userMessage: 'Validation failed - check balance and inputs before retrying.',
     }
   }
 
@@ -560,7 +560,7 @@ try {
   console.error('Execute failed:', {
     message: error.message,
     code: error.code,
-    details: error.details,
+    context: error.context,
   })
   throw error
 }
@@ -675,4 +675,4 @@ catch (error: any) {
 
 - [Integrate with wallets](/cookbook/09-wallet-integration) with error handling
 - [Test error scenarios](/cookbook/10-testing-mocks) comprehensively
-- Learn about [error codes](/reference/errors) in detail
+- Learn about [error handling patterns](/guides/error-handling/) in detail

--- a/src/content/docs/cookbook/10-testing-mocks.mdx
+++ b/src/content/docs/cookbook/10-testing-mocks.mdx
@@ -27,15 +27,16 @@ describe('SIP Integration Tests', () => {
   let sip: SIP
   let mockProvider: MockProofProvider
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // Create SIP instance in demo mode for testing
     sip = new SIP({
       network: 'testnet',
       mode: 'demo',  // Uses mock data, no real network calls
     })
 
-    // Create mock proof provider
+    // Create mock proof provider (isReady is false until initialized)
     mockProvider = new MockProofProvider()
+    await mockProvider.initialize()
 
     // Set proof provider
     sip.setProofProvider(mockProvider)
@@ -433,6 +434,7 @@ describe('SIP Integration Test Suite', () => {
     // Setup
     sip = new SIP({ network: 'testnet', mode: 'demo' })
     mockProvider = new MockProofProvider()
+    await mockProvider.initialize()  // isReady is false until initialized
     sip.setProofProvider(mockProvider)
 
     mockWallet = new MockWalletAdapter('solana')
@@ -629,6 +631,5 @@ expect(result.status).toBe('fulfilled')
 
 ## Next Steps
 
-- Learn about [E2E testing strategies](/guides/testing)
 - Review [SDK test suite](https://github.com/sip-protocol/sip-protocol/tree/main/packages/sdk/tests) for examples
-- Explore [CI/CD integration](/guides/ci-cd) for automated testing
+- Handle [errors gracefully](/cookbook/08-error-handling) in your integration tests

--- a/src/content/docs/faq.md
+++ b/src/content/docs/faq.md
@@ -219,10 +219,18 @@ import { SIP, PrivacyLevel } from '@sip-protocol/sdk'
 
 const sip = new SIP({ network: 'mainnet' })
 
-// Create shielded swap
+// Create shielded swap.
+// Amounts are bigint in the asset's smallest unit (1 ETH = 1e18 wei).
 const intent = await sip.createIntent({
-  input: { chain: 'ethereum', token: 'ETH', amount: '1.0' },
-  output: { chain: 'solana', token: 'SOL' },
+  input: {
+    asset: { chain: 'ethereum', symbol: 'ETH', address: null, decimals: 18 },
+    amount: 1_000_000_000_000_000_000n,  // 1 ETH
+  },
+  output: {
+    asset: { chain: 'solana', symbol: 'SOL', address: null, decimals: 9 },
+    minAmount: 0n,        // accept any amount
+    maxSlippage: 0.01,    // 1%
+  },
   privacy: PrivacyLevel.SHIELDED,
 })
 
@@ -230,6 +238,10 @@ const intent = await sip.createIntent({
 const quotes = await sip.getQuotes(intent)
 await sip.execute(intent, quotes[0])
 ```
+
+:::note[Mock quotes by default]
+By default the SDK runs in **demo mode**, so `getQuotes()` returns **mock** quotes for local development. For real solver quotes, configure `mode: 'production'` plus an `intentsAdapter` (mainnet only). See [Quick Start](/getting-started/).
+:::
 
 See [Quick Start](/getting-started/) for complete guide.
 
@@ -254,19 +266,16 @@ Yes. SIP is designed to work with the NEAR Intents solver network. See [Solver I
 
 ### Is there a testnet?
 
-Yes. Use the SDK with testnet configuration:
+Partially. The NEAR Intents (1Click) settlement layer that powers real quotes and swaps is **mainnet only** — there is no testnet swap path. What `network: 'testnet'` gives you is local crypto and wallet testing (stealth addresses, commitments, viewing keys, wallet adapters) against individual chain testnets:
 
 ```typescript
-const sip = new SIP({
-  network: 'testnet',
-  nearNetwork: 'testnet',
-})
+const sip = new SIP({ network: 'testnet' })
 ```
 
-Testnet uses:
-- NEAR testnet
-- Ethereum Sepolia
-- Solana devnet
+Use these for development:
+- **Crypto / wallet testing** — `network: 'testnet'` with chain testnets (NEAR testnet, Ethereum Sepolia, Solana devnet)
+- **Unit tests** — `MockSolver` to simulate quotes and fulfillment without any network
+- **Real quotes / settlement** — require `network: 'mainnet'` + `mode: 'production'` + an `intentsAdapter` (use small amounts for integration testing)
 
 ---
 

--- a/src/content/docs/getting-started.md
+++ b/src/content/docs/getting-started.md
@@ -58,10 +58,11 @@ The NEAR Intents (1Click API) operates on **mainnet only**. There is no testnet 
 ## Your First Shielded Intent
 
 ```typescript
-import { SIP, PrivacyLevel } from '@sip-protocol/sdk'
+import { SIP, PrivacyLevel, trackIntent } from '@sip-protocol/sdk'
 
 // 1. Initialize the SDK
 // Note: NEAR Intents is mainnet-only (no testnet)
+// By default the SDK runs in demo mode (mock quotes) — see the note below.
 const sip = new SIP({ network: 'mainnet' })
 
 // 2. Create a shielded intent using the builder pattern
@@ -73,14 +74,28 @@ const intent = await sip
   .build()
 
 // 3. Get quotes from solvers
-const quotes = await sip.getQuotes(intent.intent)
+const quotes = await sip.getQuotes(intent)
 
 // 4. Execute with best quote
+//    The builder returns a ShieldedIntent; wrap it with trackIntent()
+//    to get the TrackedIntent that execute() expects.
 if (quotes.length > 0) {
-  const result = await sip.execute(intent, quotes[0])
+  const result = await sip.execute(trackIntent(intent), quotes[0])
   console.log('Transaction:', result.txHash)
 }
 ```
+
+:::note[Quotes are mock by default]
+The SDK defaults to `mode: 'demo'`, which returns **mock quotes** for fast local development — `getQuotes()` does not hit any solver network. To fetch **real** solver quotes you must opt into production mode (mainnet only) and supply a NEAR Intents adapter:
+
+```typescript
+const sip = new SIP({
+  network: 'mainnet',
+  mode: 'production',
+  intentsAdapter: { jwtToken: process.env.NEAR_INTENTS_JWT },
+})
+```
+:::
 
 ### What Just Happened?
 
@@ -150,18 +165,21 @@ import {
   deriveStealthPrivateKey
 } from '@sip-protocol/sdk'
 
-// Recipient: Generate meta-address (share publicly)
-const metaAddress = generateStealthMetaAddress('ethereum')
+// Recipient: Generate meta-address (metaAddress is shared publicly;
+// keep spendingPrivateKey and viewingPrivateKey secret)
+const { metaAddress, spendingPrivateKey, viewingPrivateKey } =
+  generateStealthMetaAddress('ethereum')
 
-// Sender: Generate one-time stealth address
-const { stealthAddress, ephemeralPublicKey } = generateStealthAddress(metaAddress)
+// Sender: Generate one-time stealth address from the public meta-address
+const { stealthAddress } = generateStealthAddress(metaAddress)
 
-// Recipient: Derive private key to spend funds
+// Recipient: Derive the private key to spend funds.
+// The ephemeral public key the sender used is already carried on
+// stealthAddress, so only the recipient's two private keys are needed.
 const privateKey = deriveStealthPrivateKey(
   stealthAddress,
-  ephemeralPublicKey,
-  metaAddress.spendingKey,
-  metaAddress.viewingKey
+  spendingPrivateKey,
+  viewingPrivateKey
 )
 ```
 

--- a/src/content/docs/glossary.md
+++ b/src/content/docs/glossary.md
@@ -28,8 +28,8 @@ Encryption that provides both confidentiality and integrity. SIP uses XChaCha20-
 A random value used in Pedersen commitments to hide the actual amount. Without knowing the blinding factor, observers cannot determine the committed value.
 
 ```typescript
-const { commitment, blindingFactor } = createCommitment(amount)
-// blindingFactor: random 256-bit scalar
+const { commitment, blinding } = commit(amount)
+// blinding: random 256-bit scalar
 ```
 
 ### Bridge
@@ -275,6 +275,8 @@ A solver's offer to fulfill an intent at specified terms (exchange rate, fees, t
 const quotes = await sip.getQuotes(intent)
 // quotes: array of solver offers
 ```
+
+_In the SDK's default demo mode these are mock quotes; real solver quotes require `mode: 'production'`._
 
 ---
 

--- a/src/content/docs/guides/cross-chain-stealth.md
+++ b/src/content/docs/guides/cross-chain-stealth.md
@@ -32,17 +32,22 @@ When both chains use the same curve, SIP can automatically generate a stealth re
 ### EVM → EVM Example
 
 ```typescript
-import { createShieldedIntent } from '@sip-protocol/sdk'
+import { createShieldedIntent, PrivacyLevel } from '@sip-protocol/sdk'
 
 // Ethereum to Polygon - both use secp256k1
 const intent = await createShieldedIntent({
-  inputChain: 'ethereum',
-  outputChain: 'polygon',
-  inputAsset: 'ETH',
-  outputAsset: 'MATIC',
-  amount: '1.0',
-  recipient: recipientMetaAddress, // secp256k1 meta-address
-  // senderAddress NOT required - automatically derived
+  input: {
+    asset: { chain: 'ethereum', symbol: 'ETH', address: null, decimals: 18 },
+    amount: 1_000_000_000_000_000_000n, // 1 ETH
+  },
+  output: {
+    asset: { chain: 'polygon', symbol: 'MATIC', address: null, decimals: 18 },
+    minAmount: 0n,
+    maxSlippage: 0.01, // 1%
+  },
+  privacy: PrivacyLevel.SHIELDED,
+  recipientMetaAddress, // secp256k1 meta-address
+  // senderAddress NOT required - automatically derived (same-curve)
 })
 ```
 
@@ -51,13 +56,18 @@ const intent = await createShieldedIntent({
 ```typescript
 // Solana to NEAR - both use ed25519
 const intent = await createShieldedIntent({
-  inputChain: 'solana',
-  outputChain: 'near',
-  inputAsset: 'SOL',
-  outputAsset: 'NEAR',
-  amount: '10.0',
-  recipient: recipientMetaAddress, // ed25519 meta-address
-  // senderAddress NOT required - automatically derived
+  input: {
+    asset: { chain: 'solana', symbol: 'SOL', address: null, decimals: 9 },
+    amount: 10_000_000_000n, // 10 SOL
+  },
+  output: {
+    asset: { chain: 'near', symbol: 'NEAR', address: null, decimals: 24 },
+    minAmount: 0n,
+    maxSlippage: 0.01, // 1%
+  },
+  privacy: PrivacyLevel.SHIELDED,
+  recipientMetaAddress, // ed25519 meta-address
+  // senderAddress NOT required - automatically derived (same-curve)
 })
 ```
 
@@ -73,32 +83,50 @@ When chains use different curves, you **must** provide a `senderAddress` for ref
 
 ```typescript
 // Cross-curve: secp256k1 → ed25519
-// MUST provide senderAddress for refunds
-const intent = await createShieldedIntent({
-  inputChain: 'ethereum',
-  outputChain: 'solana',
-  inputAsset: 'ETH',
-  outputAsset: 'SOL',
-  amount: '1.0',
-  recipient: recipientMetaAddress, // ed25519 meta-address for Solana
-  senderAddress: '0x742d35Cc6634C0532925a3b844Bc9e7595f2bD11', // Your Ethereum address for refunds
-})
+// MUST provide senderAddress (in the options arg) for refunds
+const intent = await createShieldedIntent(
+  {
+    input: {
+      asset: { chain: 'ethereum', symbol: 'ETH', address: null, decimals: 18 },
+      amount: 1_000_000_000_000_000_000n, // 1 ETH
+    },
+    output: {
+      asset: { chain: 'solana', symbol: 'SOL', address: null, decimals: 9 },
+      minAmount: 0n,
+      maxSlippage: 0.01, // 1%
+    },
+    privacy: PrivacyLevel.SHIELDED,
+    recipientMetaAddress, // ed25519 meta-address for Solana
+  },
+  {
+    senderAddress: '0x742d35Cc6634C0532925a3b844Bc9e7595f2bD11', // Your Ethereum address for refunds
+  },
+)
 ```
 
 ### Solana → EVM Example
 
 ```typescript
 // Cross-curve: ed25519 → secp256k1
-// MUST provide senderAddress for refunds
-const intent = await createShieldedIntent({
-  inputChain: 'solana',
-  outputChain: 'ethereum',
-  inputAsset: 'SOL',
-  outputAsset: 'ETH',
-  amount: '10.0',
-  recipient: recipientMetaAddress, // secp256k1 meta-address for Ethereum
-  senderAddress: 'DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK', // Your Solana address for refunds
-})
+// MUST provide senderAddress (in the options arg) for refunds
+const intent = await createShieldedIntent(
+  {
+    input: {
+      asset: { chain: 'solana', symbol: 'SOL', address: null, decimals: 9 },
+      amount: 10_000_000_000n, // 10 SOL
+    },
+    output: {
+      asset: { chain: 'ethereum', symbol: 'ETH', address: null, decimals: 18 },
+      minAmount: 0n,
+      maxSlippage: 0.01, // 1%
+    },
+    privacy: PrivacyLevel.SHIELDED,
+    recipientMetaAddress, // secp256k1 meta-address for Ethereum
+  },
+  {
+    senderAddress: 'DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK', // Your Solana address for refunds
+  },
+)
 ```
 
 ## Error Messages
@@ -174,12 +202,30 @@ function needsSenderAddress(inputChain: string, outputChain: string): boolean {
 
 Ensure the `senderAddress` matches the input chain's expected format:
 
-```typescript
-import { validateAddress } from '@sip-protocol/sdk'
+The SDK exposes chain-specific validators. Dispatch on the input chain to
+validate the refund address:
 
-// Validates address format for the chain
-const isValid = validateAddress(senderAddress, inputChain)
-if (!isValid) {
+```typescript
+import {
+  isValidSolanaAddress,
+  isValidNearImplicitAddress,
+  isValidNearAccountId,
+} from '@sip-protocol/sdk'
+
+function isValidAddress(address: string, chain: string): boolean {
+  switch (chain) {
+    case 'solana':
+      return isValidSolanaAddress(address)
+    case 'near':
+      // NEAR accepts implicit (64-hex) accounts and named accounts (alice.near)
+      return isValidNearImplicitAddress(address) || isValidNearAccountId(address)
+    default:
+      // EVM chains (ethereum, polygon, arbitrum, base, ...): 0x + 40 hex chars
+      return /^0x[0-9a-fA-F]{40}$/.test(address)
+  }
+}
+
+if (!isValidAddress(senderAddress, inputChain)) {
   throw new Error(`Invalid ${inputChain} address format`)
 }
 ```

--- a/src/content/docs/guides/error-handling.mdx
+++ b/src/content/docs/guides/error-handling.mdx
@@ -132,7 +132,7 @@ try {
 
 **Example:**
 ```typescript
-import { NoirProofProvider } from '@sip-protocol/sdk'
+import { NoirProofProvider } from '@sip-protocol/sdk/proofs/noir'
 
 const provider = new NoirProofProvider({ wasmPath: '/noir' })
 
@@ -308,6 +308,9 @@ const quotes = await withExponentialBackoff(() => sip.getQuotes(intent))
 For proof generation failures:
 
 ```typescript
+import { NoirProofProvider } from '@sip-protocol/sdk/proofs/noir'
+import { MockProofProvider } from '@sip-protocol/sdk'
+
 const providers = [
   new NoirProofProvider({ wasmPath: '/noir' }),
   new MockProofProvider(), // Fallback for testing
@@ -382,6 +385,8 @@ const result = await breaker.execute(() => sip.execute(intent, quote))
 For optional features:
 
 ```typescript
+import { NoirProofProvider } from '@sip-protocol/sdk/proofs/noir'
+
 async function createIntent(withProofs = true) {
   const builder = sip.intent()
     .input('solana', 'SOL', 1_000_000_000n)
@@ -393,7 +398,7 @@ async function createIntent(withProofs = true) {
       // Try to generate proofs
       const proofProvider = new NoirProofProvider({ wasmPath: '/noir' })
       await proofProvider.initialize()
-      builder.proofsProvider(proofProvider)
+      builder.withProvider(proofProvider)
     } catch (e) {
       console.warn('Proof generation not available, continuing without proofs:', e)
       // Continue without proofs (for development)
@@ -509,7 +514,7 @@ try {
   await rejectingWallet.connect()
 } catch (e) {
   expect(e).toBeInstanceOf(WalletError)
-  expect(e.walletCode).toBe('WALLET_CONNECTION_REJECTED')
+  expect(e.walletCode).toBe('WALLET_CONNECTION_FAILED')
 }
 
 // Test signing rejection
@@ -522,7 +527,7 @@ try {
   await rejectingWallet2.signMessage(new Uint8Array([1, 2, 3]))
 } catch (e) {
   expect(e).toBeInstanceOf(WalletError)
-  expect(e.walletCode).toBe('WALLET_SIGNING_REJECTED')
+  expect(e.walletCode).toBe('WALLET_SIGNING_FAILED')
 }
 ```
 
@@ -553,10 +558,13 @@ if (balance < intent.inputAmount) {
   })
 }
 
-// 2. Increase slippage tolerance
-const quote = await sip.getQuotes(intent, {
-  slippageTolerance: 100, // 1% (in basis points)
-})
+// 2. Increase slippage tolerance on the intent itself (1% = .slippage(1))
+const intentWithSlippage = await sip.intent()
+  .input('solana', 'SOL', 1_000_000_000n)
+  .output('zcash', 'ZEC', 50_000_000n)
+  .slippage(1) // 1%
+  .build()
+const quote = await sip.getQuotes(intentWithSlippage)
 
 // 3. Check quote expiry
 const now = Math.floor(Date.now() / 1000)
@@ -598,29 +606,23 @@ import {
   generateStealthMetaAddress,
   encodeStealthMetaAddress,
   decodeStealthMetaAddress,
-  validateStealthAddress
 } from '@sip-protocol/sdk'
 
-// ✅ Generate valid stealth address
-const keys = generateStealthMetaAddress()
-const encoded = encodeStealthMetaAddress(keys, 'solana')
+// ✅ Generate valid stealth meta-address (chain is required)
+const keys = generateStealthMetaAddress('solana')
+const encoded = encodeStealthMetaAddress(keys.metaAddress)
 
 // Validate format: sip:solana:<spendingKey>:<viewingKey>
 if (!encoded.startsWith('sip:solana:')) {
   throw new ValidationError('Invalid stealth address format')
 }
 
-// ✅ Decode safely
+// ✅ Decode safely — decodeStealthMetaAddress validates the keys and
+// throws a ValidationError if the format or curve is wrong
 try {
   const decoded = decodeStealthMetaAddress(encoded)
   console.log('Valid stealth address:', decoded)
 } catch (e) {
-  console.error('Invalid stealth address:', e)
-}
-
-// ✅ Use helper function
-const isValid = validateStealthAddress(encoded, 'solana')
-if (!isValid) {
   throw new ValidationError('Invalid stealth address for chain', 'stealthAddress')
 }
 ```
@@ -640,7 +642,8 @@ if (!isValid) {
 **Troubleshooting:**
 
 ```typescript
-import { NoirProofProvider } from '@sip-protocol/sdk'
+import { NoirProofProvider } from '@sip-protocol/sdk/proofs/noir'
+import { commit, generateRandomBytes } from '@sip-protocol/sdk'
 
 const provider = new NoirProofProvider({ wasmPath: '/noir' })
 
@@ -648,16 +651,20 @@ const provider = new NoirProofProvider({ wasmPath: '/noir' })
 await provider.initialize()
 
 // 2. Generate proof with correct parameters
+const balance = 1000n
+const blindingFactor = generateRandomBytes(32) // 32-byte Uint8Array
 const proofResult = await provider.generateFundingProof({
-  balance: 1000n,
+  balance,
   minimumRequired: 100n,
+  blindingFactor, // Use same blinding as commitment
   assetId: 'SOL',
-  blinding: generateBlinding(), // Use same blinding as commitment
+  userAddress: wallet.address,
+  ownershipSignature, // Signature over userAddress
 })
 
 // 3. Verify proof with matching public inputs
 const publicInputs = {
-  commitment: pedersen(balance, blinding), // Must match!
+  commitment: commit(balance, blindingFactor).commitment, // Must match!
   minimumRequired: 100n,
   assetId: 'SOL',
 }
@@ -741,7 +748,7 @@ const signature = await wallet.signMessage(message)
 **Solutions:**
 
 ```typescript
-import { commit, verifyOpening, addCommitments } from '@sip-protocol/sdk'
+import { commit, verifyOpening, addCommitments, addBlindings } from '@sip-protocol/sdk'
 
 // ✅ Store blinding factor with commitment
 const amount = 1000n
@@ -768,9 +775,9 @@ const c1 = commit(100n)
 const c2 = commit(200n)
 const sum = addCommitments(c1.commitment, c2.commitment)
 
-// Verify sum (must use sum of blindings)
-const totalBlinding = (c1.blinding + c2.blinding) % CURVE_ORDER
-verifyOpening(sum, 300n, totalBlinding) // ✅
+// Verify sum (must use sum of blindings — addBlindings sums them mod the curve order)
+const totalBlinding = addBlindings(c1.blinding, c2.blinding)
+verifyOpening(sum.commitment, 300n, totalBlinding) // ✅
 ```
 
 <Aside type="tip">

--- a/src/content/docs/guides/ethereum-privacy.md
+++ b/src/content/docs/guides/ethereum-privacy.md
@@ -124,29 +124,44 @@ console.log('Send to:', ethAddress) // 0x742d35Cc6634C0532925a3b844Bc454e4438f44
 
 ### Scanning with View Tag
 
-The view tag enables efficient scanning:
+On EVM chains you fetch stealth-address announcements from your indexer or the
+`StealthAddressRegistry` contract, then check each announcement against your
+keys with `checkStealthAddress`. The view tag (first byte of the shared-secret
+hash) lets you cheaply reject most non-matching announcements before doing the
+full elliptic-curve check:
 
 ```typescript
-import { scanForStealthPayments } from '@sip-protocol/sdk'
+import { checkStealthAddress, deriveStealthPrivateKey } from '@sip-protocol/sdk'
 
-// Scan Ethereum for payments
-const payments = await scanForStealthPayments({
-  chain: 'ethereum',
-  viewingPrivateKey: myMetaAddress.viewingPrivateKey,
-  spendingPublicKey: myMetaAddress.metaAddress.spendingKey,
-  fromBlock: 19000000,
-  rpcUrl: 'https://mainnet.infura.io/v3/YOUR_KEY',
-})
+// announcements come from your indexer / on-chain registry events:
+// { stealthAddress, ephemeralPublicKey, viewTag, amount, txHash }
+for (const ann of announcements) {
+  const stealthAddress = {
+    address: ann.stealthAddress,
+    ephemeralPublicKey: ann.ephemeralPublicKey,
+    viewTag: ann.viewTag,
+  }
 
-for (const payment of payments) {
-  // View tag allows quick rejection of non-matching payments
-  if (payment.viewTag !== expectedViewTag) continue
+  // Full check: does this stealth address belong to us?
+  const isMine = checkStealthAddress(
+    stealthAddress,
+    myMetaAddress.spendingPrivateKey,
+    myMetaAddress.viewingPrivateKey,
+  )
+  if (!isMine) continue
 
   console.log('Payment found:', {
-    amount: ethers.formatEther(payment.amount),
-    txHash: payment.txHash,
-    block: payment.blockNumber,
+    amount: ethers.formatEther(ann.amount),
+    txHash: ann.txHash,
   })
+
+  // Derive the spending key so you can move the funds
+  const recovery = deriveStealthPrivateKey(
+    stealthAddress,
+    myMetaAddress.spendingPrivateKey,
+    myMetaAddress.viewingPrivateKey,
+  )
+  // recovery.privateKey controls ann.stealthAddress
 }
 ```
 
@@ -199,9 +214,10 @@ console.log('View tag:', prepared.stealthAddress?.viewTag)
 Privacy with viewing key for regulatory compliance:
 
 ```typescript
-import { createViewingKey, encryptForViewing } from '@sip-protocol/sdk'
+import { generateViewingKey, encryptForViewing } from '@sip-protocol/sdk'
 
-const viewingKey = createViewingKey()
+// Returns { key, path, hash } — symmetric, no public/private split
+const viewingKey = generateViewingKey('m/0/auditor')
 
 const prepared = await nearAdapter.prepareSwap(
   {
@@ -221,11 +237,9 @@ const encryptedAuditData = encryptForViewing(
     sender: senderAddress,
     recipient: recipientAddress,
     amount: '10.0',
-    asset: 'ETH',
     timestamp: Date.now(),
-    purpose: 'Payment for consulting services',
   },
-  auditorPublicKey,
+  viewingKey,
 )
 ```
 

--- a/src/content/docs/guides/near-privacy.md
+++ b/src/content/docs/guides/near-privacy.md
@@ -55,10 +55,11 @@ import {
 } from '@sip-protocol/sdk'
 
 // Generate meta-address for NEAR (uses ed25519)
+// Returns: { metaAddress, spendingPrivateKey, viewingPrivateKey }
 const metaAddress = generateEd25519StealthMetaAddress('near')
 
-// Encode for sharing
-const encoded = encodeStealthMetaAddress(metaAddress)
+// Encode the public meta-address for sharing
+const encoded = encodeStealthMetaAddress(metaAddress.metaAddress)
 console.log('Share this address:', encoded)
 // Output: sip:near:0x...spendingKey...:0x...viewingKey...
 
@@ -149,10 +150,10 @@ console.log('Ephemeral key:', prepared.stealthAddress?.ephemeralPublicKey)
 Privacy with viewing key for authorized auditors:
 
 ```typescript
-import { createViewingKey, encryptForViewing } from '@sip-protocol/sdk'
+import { generateViewingKey, encryptForViewing } from '@sip-protocol/sdk'
 
-// Create viewing key pair
-const viewingKey = createViewingKey()
+// Create a viewing key (returns { key, path, hash })
+const viewingKey = generateViewingKey('m/0/auditor')
 
 const prepared = await nearAdapter.prepareSwap(
   {
@@ -174,46 +175,57 @@ const encryptedDetails = encryptForViewing(
     amount: '1000000000000000000000000',
     timestamp: Date.now(),
   },
-  viewingKey.publicKey,
+  viewingKey,
 )
 
 // Store encryptedDetails on-chain or in database
-// Auditor can decrypt with viewingKey.privateKey
+// Auditor can decrypt with the same viewingKey (decryptWithViewing)
 ```
 
 ## Scanning for Payments
 
-Recipients scan for incoming stealth payments:
+Recipients scan the chain for incoming stealth payments using
+`getTransactionHistory`, which derives the stealth addresses that belong to
+your viewing key and returns the matching transactions:
 
 ```typescript
 import {
-  scanForStealthPayments,
+  getTransactionHistory,
   deriveStealthPrivateKey,
 } from '@sip-protocol/sdk'
 
-// Scan NEAR chain for payments to your meta-address
-const payments = await scanForStealthPayments({
-  chain: 'near',
-  viewingPrivateKey: myMetaAddress.viewingPrivateKey,
-  spendingPublicKey: myMetaAddress.spendingPublicKey,
-  fromBlock: 100000000, // Start block
+// Scan NEAR for transactions belonging to your keys
+const history = await getTransactionHistory({
+  rpcUrl: 'https://rpc.mainnet.near.org',
+  viewingPrivateKey: metaAddress.viewingPrivateKey,
+  spendingPrivateKey: metaAddress.spendingPrivateKey,
+  network: 'mainnet',
+  limit: 50,
 })
 
-for (const payment of payments) {
+for (const tx of history.transactions) {
   console.log('Found payment:', {
-    amount: payment.amount,
-    txHash: payment.txHash,
-    ephemeralKey: payment.ephemeralPublicKey,
+    amount: tx.amountFormatted,
+    token: tx.token,
+    txHash: tx.hash,
+    ephemeralKey: tx.ephemeralPublicKey,
   })
 
+  // Reconstruct the stealth address from the transaction
+  const stealthAddress = {
+    address: tx.stealthPublicKey,
+    ephemeralPublicKey: tx.ephemeralPublicKey,
+    viewTag: tx.viewTag,
+  }
+
   // Derive the private key to claim this payment
-  const stealthPrivateKey = deriveStealthPrivateKey(
-    myMetaAddress.spendingPrivateKey,
-    myMetaAddress.viewingPrivateKey,
-    payment.ephemeralPublicKey,
+  const recovery = deriveStealthPrivateKey(
+    stealthAddress,
+    metaAddress.spendingPrivateKey,
+    metaAddress.viewingPrivateKey,
   )
 
-  // Use stealthPrivateKey to sign transactions from this address
+  // Use recovery.privateKey to sign transactions from this address
 }
 ```
 
@@ -222,15 +234,16 @@ for (const payment of payments) {
 ### Creating Viewing Keys
 
 ```typescript
-import { createViewingKey } from '@sip-protocol/sdk'
+import { generateViewingKey } from '@sip-protocol/sdk'
 
-const viewingKey = createViewingKey()
+const viewingKey = generateViewingKey('m/0/auditor')
 
-// Public key - share with auditors
-console.log('Auditor key:', viewingKey.publicKey)
+// The viewing key is symmetric — there is no public/private split.
+// Share the whole key with authorized auditors so they can decrypt.
+console.log('Auditor key:', viewingKey.key)
 
-// Private key - keep secure, used for decryption
-console.log('Private key:', viewingKey.privateKey)
+// Hash uniquely identifies which key can decrypt a given payload
+console.log('Key hash:', viewingKey.hash)
 ```
 
 ### Selective Disclosure
@@ -238,38 +251,44 @@ console.log('Private key:', viewingKey.privateKey)
 Share viewing keys for specific transactions:
 
 ```typescript
-import { encryptForViewing, decryptWithViewingKey } from '@sip-protocol/sdk'
+import { encryptForViewing, decryptWithViewing } from '@sip-protocol/sdk'
 
-// Sender encrypts transaction details
+// Sender encrypts transaction details with the auditor's viewing key
 const encrypted = encryptForViewing(
   {
-    txHash: '0x...',
     sender: 'alice.near',
     recipient: 'bob.near',
     amount: '1000000000000000000000000',
-    memo: 'Payment for services',
+    timestamp: Date.now(),
   },
-  auditorPublicKey,
+  viewingKey,
 )
 
-// Auditor decrypts with their private key
-const details = decryptWithViewingKey(encrypted, auditorPrivateKey)
+// Auditor decrypts with the same viewing key
+const details = decryptWithViewing(encrypted, viewingKey)
 console.log('Transaction details:', details)
 ```
 
 ### Time-Limited Access
 
-Create viewing keys with expiry:
+Derive a viewing key that is only valid for a specific time window using
+`createTimeWindowedKey`. The auditor can decrypt payments within the window,
+but the key carries no authority outside `[windowStart, windowEnd]`:
 
 ```typescript
-import { createTimeLimitedViewingKey } from '@sip-protocol/sdk'
+import { createTimeWindowedKey } from '@sip-protocol/sdk'
 
-const tempKey = createTimeLimitedViewingKey({
-  expiresAt: Date.now() + 24 * 60 * 60 * 1000, // 24 hours
-  scope: ['transaction:view'], // Limited permissions
-})
+const now = Math.floor(Date.now() / 1000)
 
-// Key automatically expires after 24 hours
+const windowedKey = createTimeWindowedKey(
+  masterViewingKey.key, // master viewing key (hex)
+  now,                  // window start (Unix seconds)
+  now + 24 * 60 * 60,   // window end — 24 hours later
+)
+
+console.log('Valid from:', windowedKey.windowStart)
+console.log('Valid until:', windowedKey.windowEnd)
+console.log('Epochs covered:', windowedKey.epochs)
 ```
 
 ## NEP-141 Token Privacy

--- a/src/content/docs/guides/solver-integration.md
+++ b/src/content/docs/guides/solver-integration.md
@@ -95,14 +95,19 @@ async generateQuote(intent: SolverVisibleIntent): Promise<SolverQuote | null> {
   const outputWithSpread = baseOutput + (baseOutput * BigInt(spread)) / 10000n
   const fee = (outputWithSpread * BigInt(feePercent)) / 10000n
 
+  // Generate a unique quote ID (e.g. crypto.randomUUID())
+  const quoteId = crypto.randomUUID()
+  const validUntil = Math.floor(Date.now() / 1000) + 60
+
   return {
-    quoteId: generateQuoteId(),
+    quoteId,
     intentId: intent.intentId,
     solverId: this.info.id,
     outputAmount: outputWithSpread,
     estimatedTime: 30,
-    expiry: Math.floor(Date.now() / 1000) + 60,
+    expiry: validUntil,
     fee,
+    validUntil, // Required by SolverQuote
     signature: await this.signQuote(quoteId, outputWithSpread),
   }
 }
@@ -139,12 +144,14 @@ async fulfill(
       status: IntentStatus.FULFILLED,
       outputAmount: quote.outputAmount,
       fulfillmentProof: proof,
+      fulfilledAt: Date.now(),
     }
   } catch (error) {
     return {
       intentId: intent.intentId,
       status: IntentStatus.FAILED,
       error: error.message,
+      fulfilledAt: Date.now(),
     }
   }
 }
@@ -162,6 +169,7 @@ const capabilities: SolverCapabilities = {
   ]),
   supportsShielded: true,
   supportsCompliant: true,
+  supportsPartialFill: false, // Required: streaming / partial fills
   avgFulfillmentTime: 30,
 }
 ```

--- a/src/content/docs/integrations/near-intents.md
+++ b/src/content/docs/integrations/near-intents.md
@@ -12,6 +12,20 @@ NEAR Intents (1Click API) operates on **mainnet only**. There is no testnet depl
 For testing, use `MockSolver` or small mainnet amounts ($5-10).
 :::
 
+:::danger[Demo mode is the default]
+`new SIP({ network })` runs in **`mode: 'demo'`** by default — `getQuotes()` returns **mock quotes**, not real 1Click prices. For real cross-chain quotes, pass `mode: 'production'` + an `intentsAdapter` (mainnet only):
+
+```typescript
+const sip = new SIP({
+  network: 'mainnet',
+  mode: 'production',
+  intentsAdapter: { jwtToken: process.env.NEAR_INTENTS_JWT }
+})
+```
+
+Or use the `createProductionSIP({ network, jwtToken })` one-liner. Production mode also requires stealth keys for privacy modes — call `sip.generateStealthKeys(chain)` or pass `recipientMetaAddress` to `getQuotes()`, otherwise it throws.
+:::
+
 ## Architecture
 
 ```
@@ -46,70 +60,106 @@ User Intent → SIP (privacy) → NEAR Intents → Multi-chain Settlement
 The 1Click API provides simplified cross-chain swaps:
 
 ```typescript
-import { OneClickClient } from '@sip-protocol/sdk'
+import { OneClickClient, OneClickSwapType } from '@sip-protocol/sdk'
 
 const client = new OneClickClient({
   baseUrl: 'https://1click.chaindefuser.com',
-  apiKey: 'optional-api-key'
+  jwtToken: process.env.NEAR_INTENTS_JWT // optional bearer token
 })
 
-// Get quote
-const quote = await client.getQuote({
-  srcChainId: 'ethereum',
-  srcToken: 'ETH',
-  dstChainId: 'solana',
-  dstToken: 'SOL',
-  amount: '1000000000000000000', // 1 ETH in wei
-  slippage: 0.5
+// Request a quote. The 1Click API uses Defuse asset IDs (NEP-141 format)
+// and slippage in basis points (100 = 1%).
+const quote = await client.quote({
+  swapType: OneClickSwapType.EXACT_INPUT,
+  originAsset: 'nep141:wrap.near',
+  destinationAsset: 'nep141:sol.omft.near',
+  amount: '1000000000000000000000000', // 1 NEAR (24 decimals)
+  refundTo: 'user.near',
+  recipient: '...solana-address...',
+  depositType: 'ORIGIN_CHAIN',
+  refundType: 'ORIGIN_CHAIN',
+  recipientType: 'DESTINATION_CHAIN',
+  slippageTolerance: 100, // basis points
+  deadline: new Date(Date.now() + 3600_000).toISOString()
 })
 
-// Execute swap
-const result = await client.executeSwap({
-  quote,
-  senderAddress: '0x...',
-  recipientAddress: '...'
-})
+// `quote.depositAddress` is where the user deposits input tokens.
+// OneClickClient does NOT execute swaps — the user deposits to depositAddress,
+// then status is tracked via client.getStatus(quote.depositAddress).
+const status = await client.getStatus(quote.depositAddress)
 ```
+
+:::note
+`OneClickClient` is a thin HTTP wrapper. It fetches quotes and tracks status — it
+does **not** sign or broadcast deposits. Execution happens off-client (the user
+deposits to `depositAddress`) or via the higher-level `NEARIntentsAdapter` /
+`sip.execute()` flow.
+:::
 
 ## NEARIntentsAdapter
 
 Full adapter for NEAR Intents integration:
 
 ```typescript
-import { NEARIntentsAdapter, createNEARIntentsAdapter } from '@sip-protocol/sdk'
+import { NEARIntentsAdapter, createNEARIntentsAdapter, PrivacyLevel } from '@sip-protocol/sdk'
 
 const adapter = createNEARIntentsAdapter({
-  network: 'mainnet',  // NEAR Intents is mainnet-only
-  endpoint: 'https://1click.chaindefuser.com'
+  // NEAR Intents is mainnet-only; the adapter targets the 1Click API directly.
+  baseUrl: 'https://1click.chaindefuser.com',
+  jwtToken: process.env.NEAR_INTENTS_JWT // optional bearer token
 })
 
-// Prepare swap
-const preparedSwap = await adapter.prepareSwap({
-  inputChain: 'ethereum',
-  inputToken: 'ETH',
-  inputAmount: 1_000_000_000_000_000_000n,
-  outputChain: 'solana',
-  outputToken: 'SOL',
-  sender: '0x...',
-  recipient: '...',
-  slippage: 0.5
-})
+// Build a swap request. Assets use the SIP `Asset` shape ({ chain, symbol,
+// address, decimals }); amounts are bigint in smallest units.
+const request = {
+  requestId: crypto.randomUUID(),
+  privacyLevel: PrivacyLevel.SHIELDED,
+  inputAsset: { chain: 'ethereum', symbol: 'ETH', address: null, decimals: 18 },
+  inputAmount: 1_000_000_000_000_000_000n, // 1 ETH
+  outputAsset: { chain: 'solana', symbol: 'SOL', address: null, decimals: 9 }
+}
 
-// Execute
-const result = await adapter.executeSwap(preparedSwap)
-console.log('Tx hash:', result.txHash)
+// initiateSwap() prepares the swap (deriving a stealth recipient for privacy
+// modes), fetches a quote, and returns deposit instructions.
+const result = await adapter.initiateSwap(request, recipientMetaAddress, senderEthAddress)
+console.log('Deposit to:', result.depositAddress)
+console.log('Expected out:', result.amountOut)
+
+// After the user deposits to result.depositAddress, notify + wait for settlement:
+await adapter.notifyDeposit(result.depositAddress, depositTxHash)
+const finalStatus = await adapter.waitForCompletion(result.depositAddress)
+console.log('Final status:', finalStatus.status)
 ```
+
+:::note
+For finer control use the lower-level steps directly: `adapter.prepareSwap(request, recipientMetaAddress, senderAddress)` → `adapter.getQuote(prepared)` → deposit → `adapter.notifyDeposit(...)` → `adapter.waitForCompletion(...)`. There is no `executeSwap()` — the adapter never signs the deposit; the user (or wallet) sends funds to `depositAddress`.
+:::
 
 ## Configuration
 
 ```typescript
 interface NEARIntentsAdapterConfig {
-  network: 'mainnet' | 'testnet'
-  endpoint?: string           // 1Click API URL
-  apiKey?: string             // Optional API key
-  timeout?: number            // Request timeout (ms)
+  client?: OneClickClient            // Provide a pre-built client (optional)
+  baseUrl?: string                   // 1Click API URL
+  jwtToken?: string                  // Optional bearer token
+  defaultSlippage?: number           // Basis points (default: 100 = 1%)
+  defaultDeadlineOffset?: number     // Seconds (default: 3600)
+  assetMappings?: Record<string, string> // Override SIP→Defuse asset IDs
+  enableFees?: boolean               // Collect protocol fees (default: true)
+  feeConfig?: {                      // Custom fee configuration
+    baseBps?: number
+    disableViewingKeyDiscount?: boolean
+    treasuryAccount?: string
+  }
 }
 ```
+
+:::note
+There is no `network` field — NEAR Intents is mainnet-only, so the adapter
+always targets the production 1Click API. Authentication uses `jwtToken`
+(a bearer token), not an `apiKey`. The underlying `OneClickClient` accepts
+`{ baseUrl, jwtToken, timeout, fetch }`.
+:::
 
 ### Network Endpoints
 
@@ -140,7 +190,12 @@ SIP adds privacy layer before NEAR Intents settlement:
 ```typescript
 import { SIP, PrivacyLevel } from '@sip-protocol/sdk'
 
-const sip = new SIP({ network: 'mainnet' })
+// Production mode is required for real NEAR Intents quotes (mainnet only).
+const sip = new SIP({
+  network: 'mainnet',
+  mode: 'production',
+  intentsAdapter: { jwtToken: process.env.NEAR_INTENTS_JWT }
+})
 
 // Create shielded intent
 const intent = await sip
@@ -194,12 +249,12 @@ ws.send(JSON.stringify({
 import { NetworkError, hasErrorCode, ErrorCode } from '@sip-protocol/sdk'
 
 try {
-  const quote = await client.getQuote(params)
+  const quote = await client.quote(params)
 } catch (error) {
-  if (hasErrorCode(error, ErrorCode.NETWORK_ERROR)) {
-    console.error('Network error:', error.message)
+  if (hasErrorCode(error, ErrorCode.NETWORK_FAILED)) {
+    console.error('Network error:', (error as NetworkError).message)
     // Retry with backoff
-  } else if (error.status === 429) {
+  } else if (hasErrorCode(error, ErrorCode.RATE_LIMITED)) {
     console.error('Rate limited')
     // Wait and retry
   }
@@ -230,32 +285,54 @@ NEAR Chain Signatures enable cross-chain execution:
 ## Example: Full Flow
 
 ```typescript
-import { SIP, PrivacyLevel, createEthereumAdapter } from '@sip-protocol/sdk'
+import {
+  createProductionSIP,
+  PrivacyLevel,
+  createEthereumAdapter,
+} from '@sip-protocol/sdk'
 
 async function privateSwap() {
-  // Initialize (mainnet-only for NEAR Intents)
-  const sip = new SIP({ network: 'mainnet' })
+  // Production mode is required for real NEAR Intents quotes (mainnet only).
+  // createProductionSIP wires up the intentsAdapter for you.
+  const sip = createProductionSIP({
+    network: 'mainnet',
+    jwtToken: process.env.NEAR_INTENTS_JWT,
+  })
 
   // Connect wallet
   const adapter = createEthereumAdapter(window.ethereum)
   await adapter.connect()
   sip.connect(adapter)
 
-  // Create shielded intent
-  const intent = await sip
-    .intent()
-    .input('ethereum', 'ETH', 1_000_000_000_000_000_000n)
-    .output('solana', 'SOL')
-    .privacy(PrivacyLevel.SHIELDED)
-    .slippage(0.5)
-    .expiry(30) // 30 minutes
-    .build()
+  // Privacy modes need a stealth meta-address for the recipient.
+  const recipientMetaAddress = sip.generateStealthKeys('solana')
 
-  // Get quotes (via NEAR Intents)
-  const quotes = await sip.getQuotes(intent.intent)
+  // Production getQuotes() takes CreateIntentParams (raw input/output values).
+  const params = {
+    input: {
+      asset: { chain: 'ethereum', symbol: 'ETH', address: null, decimals: 18 },
+      amount: 1_000_000_000_000_000_000n, // 1 ETH
+    },
+    output: {
+      asset: { chain: 'solana', symbol: 'SOL', address: null, decimals: 9 },
+      minAmount: 0n,
+      maxSlippage: 0.005, // 0.5%
+    },
+    privacy: PrivacyLevel.SHIELDED,
+  }
 
-  // Execute best quote
-  const result = await sip.execute(intent, quotes[0])
+  // Get real quotes via NEAR Intents (derives a stealth recipient internally).
+  const quotes = await sip.getQuotes(params, recipientMetaAddress)
+
+  // Materialize a tracked intent, then execute the best quote.
+  const intent = await sip.createIntent(params)
+  const result = await sip.execute(intent, quotes[0], {
+    onDepositRequired: async (depositAddress, amount) => {
+      // Send `amount` to depositAddress from the connected wallet and
+      // return the deposit transaction hash.
+      return await sendDeposit(depositAddress, amount)
+    },
+  })
 
   console.log('Swap complete:', result.txHash)
 }

--- a/src/content/docs/integrations/zcash-evaluation.md
+++ b/src/content/docs/integrations/zcash-evaluation.md
@@ -57,9 +57,10 @@ SIP includes Zcash RPC client for shielded operations:
 import { ZcashRPCClient } from '@sip-protocol/sdk'
 
 const client = new ZcashRPCClient({
-  rpcUrl: 'http://localhost:8232',
-  rpcUser: 'user',
-  rpcPassword: 'password'
+  host: '127.0.0.1',
+  port: 8232,
+  username: process.env.ZCASH_RPC_USER,
+  password: process.env.ZCASH_RPC_PASS
 })
 
 // Create HD account
@@ -71,13 +72,13 @@ const { address } = await client.getAddressForAccount(
   ['sapling', 'orchard']
 )
 
-// Send shielded transaction
-const txid = await client.sendShielded({
-  from: zAddress,
-  to: recipientZAddress,
-  amount: 1.5,
-  memo: 'Private transfer'
+// Send shielded transaction (returns an operation ID for tracking)
+const operationId = await client.sendShielded({
+  fromAddress: address,
+  recipients: [{ address: recipientZAddress, amount: 1.5, memo: 'Private transfer' }]
 })
+const operation = await client.waitForOperation(operationId)
+console.log('Transaction ID:', operation.result?.txid)
 ```
 
 ### Option 3: Proof Verification
@@ -155,20 +156,27 @@ const { address } = await client.getAddressForAccount(
 ### Shielded Transactions
 
 ```typescript
-// Get balance
-const balance = await client.getShieldedBalance(address)
+// Get balance for an account (per-pool breakdown)
+const balance = await client.getAccountBalance(account)
 
-// List transactions
-const txs = await client.listShieldedTransactions(address)
+// List unspent shielded notes (incoming/received funds)
+const notes = await client.listUnspent()
 
-// Send shielded
-const txid = await client.sendShielded({
-  from: sender,
-  to: recipient,
-  amount: 10,
-  memo: 'Optional memo'
+// Send shielded (returns an operation ID; resolve to a txid via waitForOperation)
+const operationId = await client.sendShielded({
+  fromAddress: sender,
+  recipients: [{ address: recipient, amount: 10, memo: 'Optional memo' }]
 })
+const { result } = await client.waitForOperation(operationId)
+console.log('txid:', result?.txid)
 ```
+
+:::note
+`ZcashRPCClient` has no `getShieldedBalance` or `listShieldedTransactions`
+methods — use `getAccountBalance(account)` and `listUnspent()`. For a
+higher-level API (`getBalance()`, `getReceivedNotes()`), see
+`ZcashShieldedService`.
+:::
 
 ## Unified Addresses
 

--- a/src/content/docs/integrations/zcash.md
+++ b/src/content/docs/integrations/zcash.md
@@ -36,9 +36,10 @@ import { ZcashRPCClient, createZcashClient } from '@sip-protocol/sdk'
 
 // Create client
 const zcash = createZcashClient({
-  rpcUrl: 'http://localhost:8232',
-  rpcUser: 'your-rpc-user',
-  rpcPassword: 'your-rpc-password'
+  host: '127.0.0.1',
+  port: 8232,
+  username: process.env.ZCASH_RPC_USER,
+  password: process.env.ZCASH_RPC_PASS
 })
 
 // Check connection
@@ -53,13 +54,23 @@ The `ZcashRPCClient` provides full access to Zcash's shielded infrastructure.
 ### Configuration
 
 ```typescript
-interface ZcashRPCConfig {
-  rpcUrl: string       // Zcash node RPC endpoint
-  rpcUser: string      // RPC authentication user
-  rpcPassword: string  // RPC authentication password
+interface ZcashConfig {
+  host?: string        // Node host (default from ZCASH_RPC_HOST)
+  port?: number        // RPC port (default: 8232; testnet: 18232)
+  username: string     // RPC authentication user
+  password: string     // RPC authentication password
+  testnet?: boolean    // Use testnet defaults (default: false)
   timeout?: number     // Request timeout (ms, default: 30000)
+  retries?: number     // Retry attempts on network error (default: 3)
+  retryDelay?: number  // Base retry delay in ms (default: 1000)
 }
 ```
+
+:::caution[Use HTTPS in production]
+`ZcashRPCClient` uses HTTP Basic Auth, which transmits credentials in
+base64-encoded cleartext. Always terminate the connection over TLS/HTTPS in
+production and store credentials securely (e.g. environment variables).
+:::
 
 ### Account Management
 
@@ -80,23 +91,44 @@ console.log('Unified address:', address)
 
 ### Shielded Transactions
 
+For high-level shielded operations, use `ZcashShieldedService` — it manages the
+account, balances, sends, and incoming notes on top of the RPC client.
+
 ```typescript
-// Get shielded balance
-const balance = await zcash.getShieldedBalance(zAddress)
-console.log('Shielded balance:', balance, 'ZEC')
+import { createZcashShieldedService } from '@sip-protocol/sdk'
 
-// Send shielded transaction
-const txid = await zcash.sendShielded({
-  from: senderZAddress,
-  to: recipientZAddress,
-  amount: 1.5,         // Amount in ZEC
-  memo: 'Private payment'  // Optional encrypted memo
+const service = createZcashShieldedService({
+  rpcConfig: {
+    host: '127.0.0.1',
+    port: 8232,
+    username: process.env.ZCASH_RPC_USER,
+    password: process.env.ZCASH_RPC_PASS
+  }
 })
-console.log('Transaction ID:', txid)
+await service.initialize() // creates/loads the account + default address
 
-// List shielded transactions
-const transactions = await zcash.listShieldedTransactions(zAddress)
+// Get shielded balance (confirmed total + per-pool breakdown, in ZEC)
+const balance = await service.getBalance()
+console.log('Shielded balance:', balance.confirmed, 'ZEC')
+
+// Send a shielded transaction (returns a txid once the operation completes)
+const result = await service.sendShielded({
+  to: recipientZAddress,
+  amount: 1.5,             // Amount in ZEC
+  memo: 'Private payment'  // Optional encrypted memo (max 512 bytes)
+})
+console.log('Transaction ID:', result.txid)
+
+// List incoming shielded notes (received transactions)
+const received = await service.getReceivedNotes()
 ```
+
+:::note
+On the lower-level `ZcashRPCClient`, the underlying methods are
+`getAccountBalance(account)` / `listUnspent()` (there is no
+`getShieldedBalance` or `listShieldedTransactions`). The service wraps these
+into the friendlier API shown above.
+:::
 
 ### Unified Addresses (ZIP-316)
 
@@ -131,41 +163,62 @@ SIP's viewing key system is inspired by Zcash's design, enabling selective discl
 ### SIP Viewing Keys
 
 ```typescript
-import { generateViewingKey, deriveViewingKeyHash } from '@sip-protocol/sdk'
+import { generateViewingKey } from '@sip-protocol/sdk'
 
-// Generate viewing key pair
-const { viewingKey, viewingKeyHash } = generateViewingKey(spendingKey)
+// Generate a viewing key (optional BIP32-style derivation path, default 'm/0')
+const vk = generateViewingKey('m/0')
 
-// Viewing key can be shared with auditors
-// viewingKeyHash is stored on-chain for verification
-console.log('Share with auditor:', viewingKey)
-console.log('On-chain hash:', viewingKeyHash)
+// vk.key can be shared with auditors; vk.hash identifies the key
+// (and is stored on-chain for verification).
+console.log('Share with auditor:', vk.key)
+console.log('On-chain hash:', vk.hash)
 ```
 
 ### Compliance Flow
 
+In compliant mode you supply the viewing key — the SDK stores only its hash
+on-chain (`viewingKeyHash`). Hold the key itself to encrypt disclosable details
+for auditors, and share it so they can decrypt.
+
 ```typescript
-import { SIP, PrivacyLevel } from '@sip-protocol/sdk'
+import {
+  SIP,
+  PrivacyLevel,
+  generateViewingKey,
+  encryptForViewing,
+  decryptWithViewing,
+} from '@sip-protocol/sdk'
 
 const sip = new SIP({ network: 'mainnet' })
 
-// Create compliant transaction (generates viewing key)
-const intent = await sip
-  .intent()
-  .input('ethereum', 'ETH', amount)
-  .output('solana', 'SOL')
-  .privacy(PrivacyLevel.COMPLIANT)  // Includes viewing key
-  .build()
+// Generate the viewing key the auditor will receive.
+const vk = generateViewingKey('m/0')
 
-// Extract viewing key for auditor
-const viewingKey = intent.viewingKey
-console.log('Auditor viewing key:', viewingKey)
+// Create a compliant intent, supplying the viewing key.
+const intent = await sip.createIntent({
+  input: {
+    asset: { chain: 'ethereum', symbol: 'ETH', address: null, decimals: 18 },
+    amount,
+  },
+  output: {
+    asset: { chain: 'solana', symbol: 'SOL', address: null, decimals: 9 },
+    minAmount: 0n,
+    maxSlippage: 0.01,
+  },
+  privacy: PrivacyLevel.COMPLIANT,
+  viewingKey: vk.key,
+})
+console.log('On-chain viewing key hash:', intent.viewingKeyHash)
 
-// Auditor can verify transaction details
-const details = await sip.decryptWithViewingKey(
-  intent.encryptedData,
-  viewingKey
+// Encrypt the disclosable transaction details for the auditor.
+const encrypted = encryptForViewing(
+  { sender: '0x...', recipient: '...', amount: amount.toString(), timestamp: Date.now() },
+  vk,
 )
+
+// The auditor (holding vk) decrypts and verifies the details.
+const details = decryptWithViewing(encrypted, vk)
+console.log('Disclosed amount:', details.amount)
 ```
 
 ## Privacy Levels
@@ -201,28 +254,53 @@ await sip.intent()
 
 ## Zcash as Destination
 
-Route swaps through Zcash's shielded pool for maximum privacy:
+You can route swaps to ZEC so the shielded pool itself provides privacy on the
+destination side. Configure the Zcash RPC client separately — `SIPConfig` has no
+`zcashConfig` field.
+
+:::caution[No stealth output for Zcash]
+The NEAR Intents adapter does **not** derive stealth addresses for `zcash`
+output (stealth derivation is supported for EVM, Solana, and NEAR only). For a
+ZEC destination, use a direct recipient z-address with
+`PrivacyLevel.TRANSPARENT`; on-chain privacy then comes from Zcash's shielded
+pool rather than a SIP stealth address. To use SIP stealth output, target an
+EVM/Solana/NEAR chain instead.
+:::
 
 ```typescript
-import { SIP, PrivacyLevel } from '@sip-protocol/sdk'
+import { SIP, PrivacyLevel, createZcashClient } from '@sip-protocol/sdk'
 
-const sip = new SIP({
-  network: 'mainnet',
-  zcashConfig: {
-    rpcUrl: 'http://localhost:8232',
-    rpcUser: 'user',
-    rpcPassword: 'pass'
-  }
+// Zcash RPC is configured separately from the SIP client.
+const zcash = createZcashClient({
+  host: '127.0.0.1',
+  port: 8232,
+  username: process.env.ZCASH_RPC_USER,
+  password: process.env.ZCASH_RPC_PASS
 })
 
-// Swap ETH → ZEC (shielded)
-const intent = await sip
-  .intent()
-  .input('ethereum', 'ETH', ethAmount)
-  .output('zcash', 'ZEC')
-  .recipientAddress(zAddress)  // Shielded z-address
-  .privacy(PrivacyLevel.SHIELDED)
-  .build()
+// Production mode is required for real NEAR Intents swaps (mainnet only).
+const sip = new SIP({
+  network: 'mainnet',
+  mode: 'production',
+  intentsAdapter: { jwtToken: process.env.NEAR_INTENTS_JWT }
+})
+
+// Swap ETH → ZEC. Zcash output uses a transparent (direct) recipient z-address;
+// pass it as the transparentRecipient argument to getQuotes().
+const params = {
+  input: {
+    asset: { chain: 'ethereum', symbol: 'ETH', address: null, decimals: 18 },
+    amount: ethAmount,
+  },
+  output: {
+    asset: { chain: 'zcash', symbol: 'ZEC', address: null, decimals: 8 },
+    minAmount: 0n,
+    maxSlippage: 0.01,
+  },
+  privacy: PrivacyLevel.TRANSPARENT,
+}
+
+const quotes = await sip.getQuotes(params, undefined, senderEthAddress, zAddress)
 ```
 
 ## Future: Proof Composition
@@ -252,10 +330,10 @@ SIP's roadmap includes composing proofs from multiple systems:
 ## Error Handling
 
 ```typescript
-import { ZcashRPCError, hasErrorCode, ErrorCode } from '@sip-protocol/sdk'
+import { ZcashRPCError } from '@sip-protocol/sdk'
 
 try {
-  const txid = await zcash.sendShielded(params)
+  const operationId = await zcash.sendShielded(params)
 } catch (error) {
   if (error instanceof ZcashRPCError) {
     console.error('Zcash RPC error:', error.code, error.message)

--- a/src/content/docs/sdk-api/near-privacy.md
+++ b/src/content/docs/sdk-api/near-privacy.md
@@ -244,13 +244,12 @@ Generate a stealth meta-address for ed25519 chains (NEAR, Solana).
 
 ```typescript
 generateEd25519StealthMetaAddress(
-  chain?: ChainType
+  chain: ChainId,
+  label?: string,
 ): {
-  spendingPublicKey: HexString
-  viewingPublicKey: HexString
+  metaAddress: StealthMetaAddress  // { spendingKey, viewingKey, chain, label? }
   spendingPrivateKey: HexString
   viewingPrivateKey: HexString
-  chain: ChainType
 }
 ```
 
@@ -258,22 +257,25 @@ generateEd25519StealthMetaAddress(
 
 | Name | Type | Description |
 |------|------|-------------|
-| `chain` | `ChainType` | Target chain (default: 'near') |
+| `chain` | `ChainId` | Target ed25519 chain (`'near'`, `'solana'`, `'aptos'`, `'sui'`) — required, no default |
+| `label` | `string` | Optional human-readable label stored on the meta-address |
+
+**Returns:** The public meta-address is **nested** under `metaAddress`, whose public components are `spendingKey` and `viewingKey` (not `spendingPublicKey`/`viewingPublicKey`).
 
 **Example:**
 
 ```typescript
 import { generateEd25519StealthMetaAddress } from '@sip-protocol/sdk'
 
-const metaAddress = generateEd25519StealthMetaAddress('near')
+const result = generateEd25519StealthMetaAddress('near')
 
-// Public (share these)
-console.log('Spending key:', metaAddress.spendingPublicKey)
-console.log('Viewing key:', metaAddress.viewingPublicKey)
+// Public (share these) — note the nested metaAddress
+console.log('Spending key:', result.metaAddress.spendingKey)
+console.log('Viewing key:', result.metaAddress.viewingKey)
 
 // Private (keep secret!)
-console.log('Spending private:', metaAddress.spendingPrivateKey)
-console.log('Viewing private:', metaAddress.viewingPrivateKey)
+console.log('Spending private:', result.spendingPrivateKey)
+console.log('Viewing private:', result.viewingPrivateKey)
 ```
 
 ### generateEd25519StealthAddress()
@@ -303,7 +305,8 @@ import {
 } from '@sip-protocol/sdk'
 
 const recipientMeta = generateEd25519StealthMetaAddress('near')
-const { stealthAddress, sharedSecret } = generateEd25519StealthAddress(recipientMeta)
+// Pass the inner StealthMetaAddress, not the wrapper object
+const { stealthAddress, sharedSecret } = generateEd25519StealthAddress(recipientMeta.metaAddress)
 
 // Convert to NEAR address for transaction
 const nearAddress = ed25519PublicKeyToNearAddress(stealthAddress.address)
@@ -316,21 +319,32 @@ Derive the private key for a received stealth payment.
 
 ```typescript
 deriveEd25519StealthPrivateKey(
+  stealthAddress: StealthAddress,
   spendingPrivateKey: HexString,
   viewingPrivateKey: HexString,
-  ephemeralPublicKey: HexString,
-): HexString
+): StealthAddressRecovery  // { stealthAddress, ephemeralPublicKey, privateKey }
 ```
 
 **Parameters:**
 
 | Name | Type | Description |
 |------|------|-------------|
+| `stealthAddress` | `StealthAddress` | The received stealth address (its `ephemeralPublicKey` is read internally) |
 | `spendingPrivateKey` | `HexString` | Recipient's spending private key |
 | `viewingPrivateKey` | `HexString` | Recipient's viewing private key |
-| `ephemeralPublicKey` | `HexString` | Ephemeral key from the transaction |
 
-**Returns:** Private key for the stealth address
+**Returns:** A `StealthAddressRecovery` object. The spendable key is on `.privateKey`.
+
+```typescript
+const recovery = deriveEd25519StealthPrivateKey(
+  stealthAddress,
+  spendingPrivateKey,
+  viewingPrivateKey,
+)
+// Use recovery.privateKey to spend from the stealth address
+```
+
+> **Note:** The returned `privateKey` is a raw little-endian ed25519 scalar, not a standard 32-byte seed. To derive its public key, multiply the base point by the scalar (see the SDK source for `deriveEd25519StealthPrivateKey`).
 
 ## Encoding Functions
 
@@ -353,7 +367,8 @@ import {
 } from '@sip-protocol/sdk'
 
 const meta = generateEd25519StealthMetaAddress('near')
-const encoded = encodeStealthMetaAddress(meta)
+// encodeStealthMetaAddress takes the inner StealthMetaAddress
+const encoded = encodeStealthMetaAddress(meta.metaAddress)
 // Output: "sip:near:0x...spending...:0x...viewing..."
 ```
 
@@ -403,39 +418,45 @@ Low-level client for NEAR 1Click API.
 ### Constructor
 
 ```typescript
-new OneClickClient(config?: OneClickClientConfig)
+new OneClickClient(config?: OneClickConfig)
 ```
 
 ### Configuration
 
 ```typescript
-interface OneClickClientConfig {
+interface OneClickConfig {
   /** API base URL */
   baseUrl?: string  // default: 'https://1click.chaindefuser.com'
 
   /** JWT authentication token */
   jwtToken?: string
+
+  /** Request timeout in milliseconds */
+  timeout?: number  // default: 30000
+
+  /** Custom fetch implementation */
+  fetch?: typeof fetch
 }
 ```
 
 ### Methods
 
-#### getQuote()
+#### quote()
 
 ```typescript
-getQuote(request: OneClickQuoteRequest): Promise<OneClickQuoteResponse>
+quote(request: OneClickQuoteRequest): Promise<OneClickQuoteResponse>
 ```
 
 #### getStatus()
 
 ```typescript
-getStatus(depositAddress: string): Promise<OneClickStatusResponse>
+getStatus(depositAddress: string, depositMemo?: string): Promise<OneClickStatusResponse>
 ```
 
-#### getSupportedTokens()
+#### getTokens()
 
 ```typescript
-getSupportedTokens(): Promise<DefuseToken[]>
+getTokens(): Promise<OneClickToken[]>
 ```
 
 ## Error Types
@@ -466,10 +487,10 @@ Common validation errors:
 const ED25519_CHAINS = ['solana', 'near', 'aptos', 'sui'] as const
 
 // Check if a chain uses ed25519
-function isEd25519Chain(chain: ChainType): boolean
+function isEd25519Chain(chain: ChainId): boolean
 
 // Get the curve type for a chain
-function getCurveForChain(chain: ChainType): 'secp256k1' | 'ed25519'
+function getCurveForChain(chain: ChainId): 'secp256k1' | 'ed25519'
 ```
 
 ## See Also

--- a/src/content/docs/sdk-api/proof-providers.md
+++ b/src/content/docs/sdk-api/proof-providers.md
@@ -339,7 +339,7 @@ interface ProofResult {
 }
 
 interface ZKProof {
-  type: 'funding' | 'validity' | 'fulfillment'
+  type: 'funding' | 'validity' | 'fulfillment' | 'ownership'
   proof: HexString
   publicInputs: HexString[]
 }
@@ -382,8 +382,8 @@ import {
   supportsWebWorkers,
   supportsSharedArrayBuffer,
   getBrowserInfo,
-  hexToBytes,
-  bytesToHex,
+  browserHexToBytes,
+  browserBytesToHex,
 } from '@sip-protocol/sdk'
 ```
 

--- a/src/content/docs/specs/eip-5564.md
+++ b/src/content/docs/specs/eip-5564.md
@@ -173,32 +173,36 @@ The view tag enables efficient scanning by allowing quick rejection of non-match
 
 ### Scanning Process
 
+`checkStealthAddress` performs the view-tag check internally (it returns early on a tag
+mismatch before doing the full elliptic-curve derivation), so scanning is a single call
+per candidate:
+
 ```typescript
-import { checkViewTag } from '@sip-protocol/sdk'
+import { checkStealthAddress } from '@sip-protocol/sdk'
 
 // For each potential payment
 for (const payment of potentialPayments) {
-  // Quick check using view tag
-  const viewTagMatch = checkViewTag(
-    payment.ephemeralPublicKey,
+  // View tag is checked first inside checkStealthAddress; the
+  // expensive derivation only runs when the tag matches (~0.4% of the time)
+  const isMine = checkStealthAddress(
+    payment.stealthAddress,
     mySpendingPrivateKey,
-    payment.viewTag
+    myViewingPrivateKey
   )
 
-  if (!viewTagMatch) {
-    continue  // Skip - not our payment (~99.6% of payments)
-  }
-
-  // View tag matches - do full computation
-  const stealthPrivateKey = deriveStealthPrivateKey(...)
-  const computedAddress = privateKeyToAddress(stealthPrivateKey)
-
-  if (computedAddress === payment.toAddress) {
+  if (isMine) {
     // This is our payment!
     console.log('Found payment:', payment)
   }
 }
 ```
+
+:::note
+The view tag itself is exposed on each `StealthAddress` (`payment.stealthAddress.viewTag`),
+but the SDK does not export a standalone view-tag matcher. The comparison against the
+recipient's keys is performed internally by `checkStealthAddress` (and by
+`deriveStealthPrivateKey` when recovering the spending key).
+:::
 
 ### Performance Impact
 
@@ -234,9 +238,15 @@ interface IERC5564Announcer {
 
 ### SIP Integration
 
-```typescript
-import { createAnnouncerClient } from '@sip-protocol/sdk'
+:::caution[Planned]
+A high-level on-chain announcer client (`createAnnouncerClient`) is **not yet part of the
+SDK**. The snippets below illustrate the intended interface — until it ships, interact with
+the announcer contract directly through your own contract client (e.g. ethers/viem) using
+the `IERC5564Announcer` ABI above.
+:::
 
+```typescript
+// Planned API — illustrative, not yet exported by @sip-protocol/sdk
 const announcer = createAnnouncerClient({
   address: '0x...',  // EIP-5564 announcer contract
   provider: ethersProvider,
@@ -254,15 +264,15 @@ await announcer.announce({
 ### Scanning Announcements
 
 ```typescript
-// Listen for announcements
+// Planned API — illustrative, not yet exported by @sip-protocol/sdk
 const announcements = await announcer.getAnnouncements({
   fromBlock: 19000000,
   schemeId: 1,
 })
 
-// Filter using view tag
+// Each candidate is then checked with checkStealthAddress (view tag handled internally)
 const myPayments = announcements.filter(a =>
-  checkViewTag(a.ephemeralPubKey, mySpendingPrivateKey, a.viewTag)
+  checkStealthAddress(a.stealthAddress, mySpendingPrivateKey, myViewingPrivateKey)
 )
 ```
 
@@ -299,11 +309,17 @@ interface IERC6538Registry {
 }
 ```
 
+:::caution[Planned]
+ERC-6538 registry support is **planned** (see the comparison table below). A registry
+client is not yet part of the public SDK surface, and the snippets in this section are
+illustrative of the intended API. Until it ships, read/write the ERC-6538 registry directly
+through your own contract client using the `IERC6538Registry` ABI above.
+:::
+
 ### Registration
 
 ```typescript
-import { createRegistryClient } from '@sip-protocol/sdk'
-
+// Planned API — illustrative, not yet exported by @sip-protocol/sdk
 const registry = createRegistryClient({
   address: '0x...',  // ERC-6538 registry
   signer: ethers.signer,
@@ -319,7 +335,7 @@ await registry.registerKeys({
 ### Lookup
 
 ```typescript
-// Look up recipient's meta-address
+// Planned API — illustrative, not yet exported by @sip-protocol/sdk
 const recipientMeta = await registry.stealthMetaAddressOf(
   recipientEthAddress,
   1  // schemeId

--- a/src/content/docs/specs/fulfillment-proof.md
+++ b/src/content/docs/specs/fulfillment-proof.md
@@ -136,13 +136,22 @@ import { MockProofProvider, FulfillmentProofParams } from '@sip-protocol/sdk'
 const proofProvider = new MockProofProvider()
 
 const params: FulfillmentProofParams = {
-  intentId: '0x...',
-  outputCommitment: '0x...',
-  minOutput: 100n,
-  recipientStealth: '0x...',
-  outputAmount: 105n,
-  outputBlinding: '0x...',
-  txHash: '0x...'
+  intentHash: '0x...',                  // public: hash of the original intent
+  outputAmount: 105n,                   // private: actual amount delivered
+  outputBlinding: new Uint8Array(32),   // private: output commitment blinding
+  minOutputAmount: 100n,                // public: minimum required output
+  recipientStealth: '0x...',            // public: recipient's stealth address
+  solverId: 'solver-1',                 // public: solver identifier
+  solverSecret: new Uint8Array(32),     // private: solver authorization secret
+  oracleAttestation: {                  // private: oracle attestation of delivery
+    recipient: '0x...',
+    amount: 105n,
+    txHash: '0x...',
+    blockNumber: 19000000n,
+    signature: new Uint8Array(64)
+  },
+  fulfillmentTime: Date.now(),          // public: time of fulfillment
+  expiry: Date.now() + 3_600_000        // public: intent expiry
 }
 
 const result = await proofProvider.generateFulfillmentProof(params)
@@ -170,13 +179,11 @@ For cross-chain verification, an oracle may attest to delivery:
 
 ```typescript
 interface OracleAttestation {
-  intentId: string
-  chainId: string
-  txHash: string
-  recipient: string
-  amount: bigint
-  timestamp: number
-  oracleSignature: string
+  recipient: HexString    // who received the funds
+  amount: bigint          // amount received
+  txHash: HexString       // transaction hash on the destination chain
+  blockNumber: bigint     // block containing the transaction
+  signature: Uint8Array   // oracle signature (threshold sig for multi-oracle)
 }
 ```
 

--- a/src/content/docs/specs/funding-proof.md
+++ b/src/content/docs/specs/funding-proof.md
@@ -103,17 +103,19 @@ import { MockProofProvider, FundingProofParams } from '@sip-protocol/sdk'
 const proofProvider = new MockProofProvider()
 
 const params: FundingProofParams = {
-  commitmentHash: '0x...',
-  minimumAmount: 500n,
-  actualBalance: 1000n,
-  blindingFactor: '0x...'
+  balance: 1000n,                        // private: user's actual balance
+  minimumRequired: 500n,                 // public: minimum the intent needs
+  blindingFactor: new Uint8Array(32),    // private: commitment randomness
+  assetId: '0xABCD',                     // public: asset identifier
+  userAddress: '0x1234...',              // private: address for ownership proof
+  ownershipSignature: new Uint8Array(64) // private: signature proving ownership
 }
 
 const result = await proofProvider.generateFundingProof(params)
 
-if (result.valid) {
-  console.log('Proof:', result.proof)
-}
+// ProofResult = { proof, publicInputs, commitment? }
+console.log('Proof:', result.proof)
+console.log('Public inputs:', result.publicInputs)
 ```
 
 ## Proof Format
@@ -135,10 +137,8 @@ interface FundingProof {
 Solvers verify the funding proof before accepting an intent:
 
 ```typescript
-const isValid = await proofProvider.verifyProof(
-  fundingProof,
-  [commitmentHash, minimumAmount]
-)
+// verifyProof takes the proof only; public inputs travel inside the proof object
+const isValid = await proofProvider.verifyProof(fundingProof)
 
 if (!isValid) {
   throw new Error('Invalid funding proof')

--- a/src/content/docs/specs/sip-spec.md
+++ b/src/content/docs/specs/sip-spec.md
@@ -54,6 +54,9 @@ interface ShieldedIntent {
 }
 ```
 
+The on-wire `version` field is populated from the SDK's exported `SIP_VERSION` constant,
+whose current value is `'sip-v1'`.
+
 ### Commitment Format
 
 ```typescript
@@ -276,9 +279,10 @@ Constraints:
 | SIP_2002 | Invalid chain |
 | SIP_2003 | Invalid privacy level |
 | SIP_2004 | Invalid amount |
-| SIP_3000 | Crypto operation failed |
-| SIP_4000 | Proof generation failed |
-| SIP_5000 | Network error |
+| SIP_3000 | Cryptographic operation failed |
+| SIP_4000 | Proof failed |
+| SIP_5000 | Intent failed |
+| SIP_6000 | Network error |
 
 ## Version History
 

--- a/src/content/docs/specs/validity-proof.md
+++ b/src/content/docs/specs/validity-proof.md
@@ -142,11 +142,15 @@ import { MockProofProvider, ValidityProofParams } from '@sip-protocol/sdk'
 const proofProvider = new MockProofProvider()
 
 const params: ValidityProofParams = {
-  intentHash: '0x...',
-  senderCommitment: '0x...',
-  senderAddress: '0xABC...',
-  signature: '0x...',
-  blindingFactor: '0x...'
+  intentHash: '0x...',                       // public: hash of the intent
+  senderAddress: '0xABC...',                 // private: actual sender address
+  senderBlinding: new Uint8Array(32),        // private: sender commitment blinding
+  senderSecret: new Uint8Array(32),          // private: sender secret key
+  authorizationSignature: new Uint8Array(64),// private: signature authorizing the intent
+  nonce: new Uint8Array(32),                 // private: nonce for nullifier
+  timestamp: Date.now(),                     // public: intent timestamp
+  expiry: Date.now() + 3_600_000             // public: intent expiry
+  // senderPublicKey is optional — derived from senderSecret when omitted
 }
 
 const result = await proofProvider.generateValidityProof(params)

--- a/src/content/docs/specs/wallet-adapter-spec.md
+++ b/src/content/docs/specs/wallet-adapter-spec.md
@@ -13,6 +13,7 @@ The wallet adapter provides a unified interface for interacting with different b
 interface WalletAdapter {
   // Identity
   readonly chain: ChainId
+  readonly name: string
   readonly address: string | null
   readonly connected: boolean
 
@@ -20,8 +21,8 @@ interface WalletAdapter {
   connect(): Promise<void>
   disconnect(): Promise<void>
 
-  // Signing
-  signMessage(message: Uint8Array): Promise<Uint8Array>
+  // Signing — returns a Signature object, not raw bytes
+  signMessage(message: Uint8Array): Promise<Signature>
   signTransaction(transaction: unknown): Promise<unknown>
 
   // Events
@@ -29,6 +30,22 @@ interface WalletAdapter {
   off(event: WalletEvent, handler: EventHandler): void
 }
 ```
+
+`signMessage` resolves to a `Signature` object rather than raw bytes:
+
+```typescript
+interface Signature {
+  signature: HexString    // signature bytes, hex encoded
+  recoveryId?: number     // recovery id for secp256k1
+  publicKey: HexString    // signing public key, hex encoded
+}
+```
+
+:::note
+The SDK ships two related adapter abstractions: the general-purpose `WalletAdapter`
+(exported as `IWalletAdapter`) shown here, and `PrivateWalletAdapter`, which extends it with
+SIP-specific shielded-send helpers. Both return `Signature` from `signMessage`.
+:::
 
 ## Events
 
@@ -109,12 +126,16 @@ await adapter.connect()
 
 ```typescript
 abstract class BaseWalletAdapter implements WalletAdapter {
+  // Subclasses must declare their chain and a human-readable name
+  abstract readonly chain: ChainId
+  abstract readonly name: string
+
   protected state: ConnectionState = 'disconnected'
   protected eventHandlers: Map<WalletEvent, EventHandler[]>
 
   abstract connect(): Promise<void>
   abstract disconnect(): Promise<void>
-  abstract signMessage(message: Uint8Array): Promise<Uint8Array>
+  abstract signMessage(message: Uint8Array): Promise<Signature>
   abstract signTransaction(tx: unknown): Promise<unknown>
 
   emit(event: WalletEvent, data?: unknown): void {

--- a/src/content/docs/specs/zk-architecture.md
+++ b/src/content/docs/specs/zk-architecture.md
@@ -177,10 +177,19 @@ flowchart TB
 
 ```typescript
 interface ProofProvider {
+  // Framework identity and readiness
+  readonly framework: ProofFramework  // 'noir' | 'mock'
+  readonly isReady: boolean
+  initialize(): Promise<void>
+  waitUntilReady(timeoutMs?: number): Promise<void>
+
+  // Proof generation
   generateFundingProof(params: FundingProofParams): Promise<ProofResult>
   generateValidityProof(params: ValidityProofParams): Promise<ProofResult>
   generateFulfillmentProof(params: FulfillmentProofParams): Promise<ProofResult>
-  verifyProof(proof: ZKProof, publicInputs: Field[]): Promise<boolean>
+
+  // Verification — public inputs travel inside the proof
+  verifyProof(proof: ZKProof): Promise<boolean>
 }
 ```
 
@@ -195,17 +204,29 @@ const sip = new SIP({
 })
 ```
 
-### NoirProofProvider (Planned)
+### NoirProofProvider
 
-For production:
+For production proof generation in Node.js. `NoirProofProvider` ships today, but to keep
+WASM out of server/SSR bundles it is **not** re-exported from the main barrel — import it
+from the `@sip-protocol/sdk/proofs/noir` subpath (browser code uses `BrowserNoirProvider`
+from `@sip-protocol/sdk/browser`):
 
 ```typescript
+import { NoirProofProvider } from '@sip-protocol/sdk/proofs/noir'
+
+// Config is optional — bundled circuit artifacts are used by default.
+// NoirProviderConfig = { artifactsPath?, backend?, verbose?, oraclePublicKey?, strictMode? }
+const proofProvider = new NoirProofProvider({
+  strictMode: true,        // require a configured oraclePublicKey for fulfillment proofs
+  // artifactsPath: '/circuits',  // override bundled artifacts (optional)
+})
+
+// The provider must finish initializing (compile circuits, load backend) before use
+await proofProvider.initialize()
+
 const sip = new SIP({
   network: 'mainnet',
-  proofProvider: new NoirProofProvider({
-    wasmPath: '/circuits/funding.wasm',
-    circuitPath: '/circuits/'
-  })
+  proofProvider,
 })
 ```
 


### PR DESCRIPTION
## Summary

Part **1 of 4** of the comprehensive June 2026 documentation audit (#96). A parallel audit of all 59 hand-written pages against the live `@sip-protocol/sdk` **0.9.0** source surfaced substantial drift; this PR fixes the **user-facing breakage** — code examples referencing removed/renamed/nonexistent APIs — and makes the **demo-vs-production mode** distinction explicit (the clarification promised in #1073).

## What's fixed (30 files)

**Broken / wrong-signature APIs** (all re-verified against `packages/sdk/src`):
- **Viewing keys** — `createViewingKey()`/`decryptWithViewingKey()` don't exist → `generateViewingKey(path)` returning `{ key, path, hash }`, `encryptForViewing(data, ViewingKey)`, `decryptWithViewing()`
- **Stealth** — `deriveStealthPrivateKey` 4→3 args; `generateStealthMetaAddress(chain, label?)` (no `{ curve }` option); nested return `.metaAddress.spendingKey`; `scanForStealthPayments` (nonexistent) → `getTransactionHistory` (NEAR) / `checkStealthAddress` announcement loop (EVM)
- **NEAR Intents** — `OneClickClient.getQuote` → `quote()`; removed fabricated `executeSwap`; config `endpoint`/`apiKey`/`network` → `baseUrl`/`jwtToken`/`client`
- **Zcash** — `getShieldedBalance`/`listShieldedTransactions` → real `ZcashShieldedService`/RPC methods; `ZcashRPCConfig` → `ZcashConfig`
- **Intents/builder** — `createShieldedIntent` structured `{ input, output, privacy }`; `getQuotes(intent)` (not `intent.intent`); `.withProvider()`/`.recipient()` (not `.proofsProvider()`/`.viewingKey()`/`.recipientAddress()`)
- **Errors** — `ErrorCode.NETWORK_FAILED` (not `NETWORK_ERROR`); `error.context` (not `error.details`)
- **Proofs** — real `Funding`/`Validity`/`Fulfillment` param + `OracleAttestation` shapes; `verifyProof(proof)` 1-arg; `NoirProofProvider` subpath import `@sip-protocol/sdk/proofs/noir`
- **Specs** — `eip-5564` `checkStealthAddress`; `wallet-adapter` `signMessage → Signature`; `sip-spec` error-code table
- **3 literal syntax errors** in cookbook (space-in-identifier)

**#1073 — demo vs production:** the SDK defaults to `mode: 'demo'`, so `getQuotes()` returns **mock** quotes. Added `:::danger`/`:::note` callouts + production-mode snippets to **near-intents**, **getting-started**, **faq**, **glossary**.

## Verification
- `astro build` green — **1277 pages** built, Pagefind index + sitemap OK.
- Every corrected API re-verified against `packages/sdk/src` by the fix agents; the highest-risk reframes (the `scanForStealthPayments` rewrites + the #1073 near-intents rewrite) were hand-reviewed.

## Out of scope (follow-up PRs in this series)
- **PR2** — version/changelog/roadmap/known-limitations staleness (changelog still at 0.6.0; `known-limitations` falsely claims "proofs are mock / testnet-only")
- **PR3** — security-crypto accuracy (stealth scheme written backwards in crypto-assumptions/audit-checklist; UltraPlonk→UltraHonk) + design-doc banners + proof constraint counts
- **PR4** — sipher SENTINEL doc consistency → closes #96

Refs #96, #1073
