### PR TITLE
docs: refresh stale versions, changelog, roadmap, known-limitations (audit 2/4)

### DIFF
--- a/src/content/docs/architecture.md
+++ b/src/content/docs/architecture.md
@@ -5,7 +5,11 @@ description: System architecture and design of SIP Protocol
 
 # Architecture
 
-SIP Protocol operates as an application layer between user applications and the NEAR Intents settlement system.
+SIP Protocol operates as an application layer between user applications and the underlying settlement systems.
+
+:::note
+The architecture below describes the cross-chain flow via NEAR Intents. SIP also supports **same-chain privacy**: Solana and NEAR same-chain are live (M17, mainnet), and EVM same-chain is in progress (M18).
+:::
 
 ## System Overview
 
@@ -113,7 +117,10 @@ ZK proof generation interfaces:
 | Provider | Status | Use Case |
 |----------|--------|----------|
 | `MockProofProvider` | Available | Testing, development |
-| `NoirProofProvider` | Planned | Production |
+| `NoirProofProvider` | Available | Production (Node.js) — subpath import `@sip-protocol/sdk/proofs/noir` |
+| `BrowserNoirProvider` | Available | Production (browser proving) — `@sip-protocol/sdk/browser` |
+
+An on-chain UltraHonk verifier (`HonkVerifier`) is deployed for EVM verification (Sepolia and Arbitrum Sepolia).
 
 ## Data Flow
 

--- a/src/content/docs/changelog.md
+++ b/src/content/docs/changelog.md
@@ -44,6 +44,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.0] - 2026-02-27
+
+### Added - M18: Ethereum Same-Chain Privacy (Foundation)
+
+#### EVM Privacy
+- Ethereum stealth-address scanning and stealth-matching (secp256k1, EIP-5564)
+- End-to-end EVM privacy test coverage
+
+#### Solidity Contracts
+- **SIPPrivacy**, **ZKVerifier**, **PedersenVerifier**, **StealthAddressRegistry** deployed to Sepolia, Arbitrum Sepolia, Base Sepolia, and OP Sepolia
+- 105+ Foundry tests covering the contract suite
+
+## [0.8.0] - 2026-02-22
+
+### Added - M16-M17: Same-Chain Privacy (Solana + NEAR)
+
+#### Solana Same-Chain
+- `shieldedTransfer` API for the SIP Privacy Anchor program
+- Native SPL shielded transfers, stealth scanning (Helius), and same-chain executors
+- Solana RPC client migrated to `@solana/kit`
+- Sunspot ZK-verifier pipeline (Noir → Solana)
+- **SIP Privacy program deployed to Solana mainnet-beta**
+
+#### NEAR Same-Chain
+- NEAR stealth addresses, Pedersen commitments, viewing keys, and transaction history
+
+#### Privacy Infrastructure
+- C-SPL confidential SPL token support (`CSPLClient`, `CSPLTokenService`)
+- Network privacy layer (Tor / SOCKS5) for RPC
+- Winternitz vault integration (quantum-resistant storage)
+- Push-based payment webhooks
+
+> M16 (narrative) and M17 (Solana + NEAR same-chain privacy) complete.
+
+## [0.7.0] - 2025-12-05
+
+### Added - M15: Application Layer
+
+#### Hardware Wallets
+- Ledger and Trezor wallet adapters (WebUSB / WebHID / WebBluetooth transports)
+- WalletConnect integration
+
+#### Surveillance & Privacy Scoring (0.7.3)
+- `SurveillanceAnalyzer` — address-reuse, clustering, exchange-exposure, and temporal-pattern analysis with privacy scoring
+
+#### Production Hardening
+- Sentry + Prometheus monitoring in the API package
+- Structured logging, security, and DX improvements
+- High-precision values via Field types in Noir circuits
+
+---
+
 ## [0.6.0] - 2025-12-03
 
 ### Added - M14: Developer Experience
@@ -264,6 +316,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 | Version | Date | Milestone | Highlights |
 |---------|------|-----------|------------|
+| 0.9.0 | 2026-02-27 | M18 | Ethereum same-chain privacy, Solidity contracts, 105+ Foundry tests |
+| 0.8.0 | 2026-02-22 | M16-M17 | Solana + NEAR same-chain privacy, mainnet-beta, C-SPL, Tor/SOCKS5 |
+| 0.7.0 | 2025-12-05 | M15 | Hardware wallets, WalletConnect, surveillance scoring, monitoring |
 | 0.6.0 | 2025-12-03 | M14 | React hooks, CLI, REST API, docs |
 | 0.5.1 | 2025-12-03 | Bugfix | CI test fix, TypeScript build fix |
 | 0.5.0 | 2025-12-03 | M13 | Compliance, threshold keys, enterprise |

--- a/src/content/docs/comparison.md
+++ b/src/content/docs/comparison.md
@@ -105,7 +105,7 @@ A detailed comparison of SIP Protocol with other blockchain privacy solutions.
 | **Integration** | SDK for any app | Requires Zcash wallet/node |
 | **Chains** | Multi-chain | Zcash only |
 | **Swaps** | Native cross-chain | Requires bridges |
-| **Privacy strength** | Strong (secp256k1 + commitments) | Very strong (Groth16 proofs) |
+| **Privacy strength** | Strong (secp256k1 + commitments) | Very strong (Groth16 (Sapling) / Halo 2 (Orchard)) |
 | **Viewing keys** | Hierarchical | Flat (per-address) |
 | **Compliance** | Built-in | Manual key sharing |
 | **Developer experience** | TypeScript SDK | C++/Rust libraries |

--- a/src/content/docs/faq.md
+++ b/src/content/docs/faq.md
@@ -286,7 +286,7 @@ Use these for development:
 Not yet. We are actively preparing for audit:
 
 - Internal review complete
-- ![CI](https://github.com/sip-protocol/sip-protocol/actions/workflows/ci.yml/badge.svg) Comprehensive test coverage
+- Comprehensive test coverage
 - Threat model documented
 - Seeking qualified auditors
 
@@ -353,4 +353,4 @@ SIP is seeking grants from multiple foundations:
 
 - **Documentation**: [docs.sip-protocol.org](https://docs.sip-protocol.org)
 - **GitHub Issues**: [github.com/sip-protocol/sip-protocol/issues](https://github.com/sip-protocol/sip-protocol/issues)
-- **Twitter/X**: [@rz1989sol](https://x.com/rz1989sol)
+- **Twitter/X**: [@sipprotocol](https://x.com/sipprotocol)

--- a/src/content/docs/getting-started.md
+++ b/src/content/docs/getting-started.md
@@ -11,7 +11,7 @@ Get up and running with the SIP Protocol SDK in minutes.
 
 ### Requirements
 
-- Node.js 18+
+- Node.js 20+
 - TypeScript 5.0+ (recommended)
 
 ### Package Installation

--- a/src/content/docs/guides/api-migration.md
+++ b/src/content/docs/guides/api-migration.md
@@ -5,15 +5,17 @@ description: Migrate from deprecated APIs to their replacements
 
 # API Migration Guide
 
-This guide helps you migrate code that uses deprecated methods before they are removed in v0.2.0.
+This guide helps you migrate code that uses deprecated methods before they are removed.
+
+The current SDK release is **`@sip-protocol/sdk` v0.9.0**. The methods below still ship in v0.9.0 for backward compatibility, but they emit a runtime deprecation warning and are scheduled for removal in a future major release (the original removal target was 2026-06-01). Migrate now to avoid a breaking change later.
 
 ## Overview
 
-| Deprecated Method | Replacement | Removal Version |
-|-------------------|-------------|-----------------|
-| `createCommitment()` | `commit()` | v0.2.0 |
-| `verifyCommitment()` | `verifyOpening()` | v0.2.0 |
-| `generateShieldedAddress()` | `createAccount()` + `getAddressForAccount()` | v0.2.0 |
+| Deprecated Method | Replacement | Status |
+|-------------------|-------------|--------|
+| `createCommitment()` | `commit()` | Deprecated — slated for removal |
+| `verifyCommitment()` | `verifyOpening()` | Deprecated — slated for removal |
+| `generateShieldedAddress()` | `createAccount()` + `getAddressForAccount()` | Deprecated — slated for removal |
 
 ## Pedersen Commitments
 
@@ -161,17 +163,17 @@ pnpm typecheck
 
 ## Deprecation Timeline
 
-### v0.1.x (Current)
-- Deprecated methods work with console warnings
+### v0.9.0 (Current)
+- Deprecated methods still work, but emit a one-time runtime deprecation warning
 - New methods available
 - Both APIs supported
 
-### v0.2.0 (Planned)
-- Deprecated methods removed
+### Future major release
+- Deprecated methods removed (original removal target: 2026-06-01)
 - Only new APIs supported
 - **Breaking change**
 
-**Action Required:** Migrate before upgrading to v0.2.0
+**Action Required:** Migrate before the next major SDK release
 
 ## Need Help?
 

--- a/src/content/docs/guides/deployment.md
+++ b/src/content/docs/guides/deployment.md
@@ -16,9 +16,11 @@ SIP Protocol uses multiple repositories:
 | Repository | Purpose | Deployment |
 |------------|---------|------------|
 | `sip-protocol/sip-protocol` | Core SDK + Types | npm registry |
-| `sip-protocol/sip-website` | Marketing website | VPS (Docker) |
+| `sip-protocol/sip-website` | Marketing website | Vercel (Git auto-deploy) |
 | `sip-protocol/sip-app` | Privacy applications | VPS (Docker) |
-| `sip-protocol/docs-sip` | Documentation | VPS (Docker) |
+| `sip-protocol/docs-sip` | Documentation | Vercel (Git auto-deploy) |
+| `sip-protocol/blog-sip` | Blog | Vercel (Git auto-deploy) |
+| `sip-protocol/cdn-sip` | CDN assets | Vercel (Git auto-deploy) |
 
 **Privacy App:** The interactive application lives at [sip-protocol/sip-app](https://github.com/sip-protocol/sip-app) and is deployed to `app.sip-protocol.org`.
 
@@ -123,11 +125,17 @@ The demo application and marketing website are in a separate repository:
 
 **Repository:** [sip-protocol/sip-website](https://github.com/sip-protocol/sip-website)
 
-**Deployment:** VPS with Docker (blue-green deployment)
-- **Production:** sip-protocol.org (ports 5000/5001)
-- **Staging:** staging.sip-protocol.org (port 5002)
+**Deployment:** Vercel (Git-integration auto-deploy)
+- **Production:** sip-protocol.org
 
-**Architecture:**
+The marketing website migrated from the VPS to Vercel in June 2026, alongside the docs, blog, and CDN. The `sip-app` privacy application remains on the VPS (Docker).
+
+**Architecture (Vercel — docs, blog, cdn, sip-website):**
+```
+GitHub Push (main) → Vercel Git integration → build → deploy
+```
+
+**Architecture (VPS — sip-app):**
 ```
 GitHub Push → GitHub Actions → GHCR → SSH Deploy → Docker Compose
 ```
@@ -172,4 +180,4 @@ Before publishing a release:
 
 ---
 
-**Last Updated:** November 27, 2025
+**Last Updated:** June 6, 2026

--- a/src/content/docs/introduction.md
+++ b/src/content/docs/introduction.md
@@ -82,6 +82,7 @@ SIP operates as an **application layer** atop existing infrastructure:
 
 - **No protocol changes required** to underlying blockchains
 - **Integrates with NEAR Intents** settlement system
+- **Cross-chain and same-chain** — same-chain privacy on Solana and NEAR is live (mainnet), with EVM same-chain in progress
 - **Compatible with existing wallets** via wallet adapters
 - **Sub-30ms overhead** for privacy operations
 

--- a/src/content/docs/roadmap.md
+++ b/src/content/docs/roadmap.md
@@ -17,10 +17,10 @@ a16z's December 2025 thesis validates SIP's core positioning as privacy middlewa
 ## Current Status
 
 - **Phase**: 3 of 5 Complete (Foundation → Standard → Ecosystem → Same-Chain → Moat)
-- **Progress**: M16 Complete, M17 Active
+- **Progress**: M17 Complete, M18 In Progress
 - **SDK Version**: ![npm version](https://img.shields.io/npm/v/@sip-protocol/sdk)
 - **Build Status**: ![CI](https://github.com/sip-protocol/sip-protocol/actions/workflows/ci.yml/badge.svg)
-- **Test Coverage**: 6,850+ tests passing
+- **Test Coverage**: 7,624+ tests passing
 - **Packages**: 7 (@sip-protocol/sdk, types, react, react-native, cli, api + website)
 - **Chains**: 15+ supported
 - **Live**: [sip-protocol.org](https://sip-protocol.org)
@@ -73,9 +73,9 @@ Capture the same-chain privacy market — 10-20x bigger than cross-chain only.
 
 | Milestone | Focus | Status |
 |-----------|-------|--------|
-| M16 | Narrative Capture & Positioning | 🎯 Starting |
-| M17 | Solana Same-Chain Privacy (Anchor) | 🔲 Planned |
-| M18 | Ethereum Same-Chain Privacy (Solidity) | 🔲 Planned |
+| M16 | Narrative Capture & Positioning | ✅ |
+| M17 | Solana Same-Chain Privacy (Anchor) | ✅ (mainnet live) |
+| M18 | Ethereum Same-Chain Privacy (Solidity) | 🔄 In Progress |
 
 **Strategic context**: PrivacyCash (pool-based mixer) is gaining traction on Solana. SIP's cryptographic approach (Pedersen commitments + stealth addresses) is architecturally superior with compliance-ready viewing keys.
 
@@ -111,8 +111,8 @@ For detailed milestone tracking with GitHub issues, see the [full roadmap on the
 
 We welcome contributions! Current focus areas:
 
-- **M16**: Narrative capture and competitive positioning
-- **M17**: Solana same-chain privacy module
+- **M18**: Ethereum same-chain privacy (Solidity contracts, L2 support)
+- **M19**: Proof composition research (Mina, Halo2)
 - **Security**: External audit preparation
 - **Adoption**: Community feedback and integration support
 

--- a/src/content/docs/security/audit-checklist.md
+++ b/src/content/docs/security/audit-checklist.md
@@ -37,8 +37,8 @@ packages/
 
 | Dependency | Version | Purpose | Audit Status |
 |------------|---------|---------|--------------|
-| @noble/curves | ^1.2.0 | ECC operations | Audited (Trail of Bits) |
-| @noble/hashes | ^1.3.2 | Hash functions | Audited (Trail of Bits) |
+| @noble/curves | ^1.3.0 | ECC operations | Audited (Trail of Bits) |
+| @noble/hashes | ^1.3.3 | Hash functions | Audited (Trail of Bits) |
 | Noir | 1.0.0-beta.15 | ZK circuits | Aztec-maintained |
 
 ### Entry Points

--- a/src/content/docs/security/audit-preparation.md
+++ b/src/content/docs/security/audit-preparation.md
@@ -40,8 +40,8 @@ This document outlines the security audit preparation for SIP Protocol.
 
 | Metric | Current | Target |
 |--------|---------|--------|
-| Test Coverage | 89.88% | >90% |
-| Passing Tests | 1,293/1,293 | 100% |
+| Test Coverage | >90% | >90% |
+| Passing Tests | 6,716 SDK (7,624+ total across packages) | 100% |
 | Type Safety | Strict | Strict |
 | Lint Errors | 0 | 0 |
 
@@ -90,7 +90,7 @@ All noble libraries are Trail of Bits audited:
 |---------|---------|--------------|
 | @noble/curves | ^1.3.0 | Audited |
 | @noble/hashes | ^1.3.3 | Audited |
-| @noble/ciphers | ^2.0.1 | Audited |
+| @noble/ciphers | ^2.2.0 | Audited |
 
 ### Other Dependencies
 
@@ -115,6 +115,10 @@ All noble libraries are Trail of Bits audited:
 2. Mock proof security (documented as non-production)
 
 ## Test Coverage
+
+:::note
+The per-module breakdown below is a point-in-time snapshot from the v0.1.0 audit-prep cycle. The current SDK (v0.9.0) ships 6,716 tests (7,624+ total across all packages). Run `pnpm test -- --run` against the repository for live counts and coverage.
+:::
 
 ### Unit Tests
 
@@ -195,10 +199,10 @@ For audit coordination:
 
 | Date | Auditor | Scope | Status |
 |------|---------|-------|--------|
-| Q1 2025 | Pending Selection | Full SDK + Circuits | Planned |
+| Feb 2026 | Solana Audit Subsidy V (auditor TBD) | Full SDK + Circuits | Planned (application in progress) |
 
 :::note
-Audit scheduling in progress. For audit inquiries, contact security@sip-protocol.org
+Audit scheduling in progress via the Solana Audit Subsidy V program (application deadline Feb 2026). For audit inquiries, contact security@sip-protocol.org
 :::
 
 ## Post-Audit Actions

--- a/src/content/docs/security/audit-scope.md
+++ b/src/content/docs/security/audit-scope.md
@@ -6,7 +6,7 @@ description: Scope document for external security audits of SIP Protocol
 # Security Audit Scope Document
 
 **Project:** SIP Protocol (Shielded Intents Protocol)
-**Version:** 0.1.0
+**Audit Target Version:** SDK 0.1.0 baseline (current released SDK: 0.9.0)
 **Date:** November 28, 2025
 **Status:** Ready for External Audit
 
@@ -76,7 +76,7 @@ SIP Protocol is a privacy layer for cross-chain transactions built on NEAR Inten
 |------|-------|-------------|------|
 | `packages/sdk/src/proofs/interface.ts` | ~200 | Proof provider interface | Medium |
 | `packages/sdk/src/proofs/mock.ts` | ~280 | Mock provider (dev only) | Low |
-| `packages/sdk/src/proofs/noir.ts` | ~450 | Noir proof provider (real ZK) | High |
+| `packages/sdk/src/proofs/noir.ts` | ~1,213 | Noir proof provider (real ZK) | High |
 
 **Focus Areas:**
 - Interface correctness for future Noir integration
@@ -117,10 +117,10 @@ SIP Protocol is a privacy layer for cross-chain transactions built on NEAR Inten
 Core Cryptography:     ~1,420 lines (+secure-memory.ts)
 Validation/Errors:       ~870 lines
 Intent System:           ~720 lines
-Proof System:            ~930 lines (+noir.ts)
+Proof System:          ~1,693 lines (+noir.ts ~1,213)
 Integrations:          ~1,530 lines
 ─────────────────────────────────
-Total In-Scope:        ~5,470 lines
+Total In-Scope:        ~6,233 lines
 ```
 
 ### Test Coverage
@@ -145,7 +145,7 @@ Core Files:
 |------------|---------|---------|--------------|
 | @noble/curves | ^1.3.0 | secp256k1 ECC | Trail of Bits |
 | @noble/hashes | ^1.3.3 | SHA256, HKDF | Trail of Bits |
-| @noble/ciphers | ^2.0.1 | XChaCha20-Poly1305 | Trail of Bits |
+| @noble/ciphers | ^2.2.0 | XChaCha20-Poly1305 | Trail of Bits |
 
 ---
 

--- a/src/content/docs/security/internal-review.md
+++ b/src/content/docs/security/internal-review.md
@@ -12,6 +12,10 @@ description: Internal security review report for SIP Protocol SDK v0.1.0
 
 ---
 
+:::note[Point-in-time snapshot]
+This report is a historical snapshot captured against **SDK v0.1.0** (November 2025). Metrics such as dependency versions, test counts, and open recommendations reflect that release. Several recommendations below have since been addressed (e.g. memory zeroization is now implemented via `secure-memory.ts`). For the current SDK (v0.9.0), see the live source and the [Audit Preparation](/security/audit-preparation/) and [Audit Scope](/security/audit-scope/) documents.
+:::
+
 ## Executive Summary
 
 The SIP Protocol SDK demonstrates strong security practices across cryptographic implementation, input validation, and error handling. The codebase uses industry-standard audited libraries (@noble/*) and follows best practices for privacy-preserving protocols.
@@ -77,7 +81,7 @@ All cryptographic operations use @noble/hashes/utils randomBytes (CSPRNG)
 1. **Dependencies**: Uses @noble/* libraries (audited, constant-time)
    - @noble/curves v1.3.0 - secp256k1 operations
    - @noble/hashes v1.3.3 - SHA256, HKDF
-   - @noble/ciphers v2.0.1 - XChaCha20-Poly1305
+   - @noble/ciphers v2.2.0 - XChaCha20-Poly1305
 
 2. **Random Number Generation**: All crypto operations use `randomBytes` from @noble/hashes
    - stealth.ts:58-59 - Key generation

--- a/src/content/docs/security/known-limitations.md
+++ b/src/content/docs/security/known-limitations.md
@@ -15,12 +15,12 @@ This document describes the current limitations of SIP Protocol and planned miti
 
 **Impact**: Medium - Reduces anonymity set size
 
-**Current Mitigations** (v0.1.0):
+**Current Mitigations** (shipped):
 - Stealth addresses provide unlinkable one-time addresses
 - View tags add scanning obfuscation (8-bit prefix)
 - Commitments hide amounts regardless of timing
 
-**Planned Mitigations** (v0.2.0+):
+**Planned Mitigations**:
 - Randomized submission delays
 - Transaction batching across users
 - Decoy transactions (research)
@@ -63,15 +63,15 @@ This document describes the current limitations of SIP Protocol and planned miti
 
 ## Implementation Limitations
 
-### Mock Proofs (Current)
+### Proof Provider Selection
 
-**Issue**: Current proofs are mock implementations, not cryptographically sound.
+**Issue**: The SDK ships both a `MockProofProvider` (development/testing) and production-grade Noir providers. Selecting the mock provider in a production deployment provides no cryptographic soundness.
 
-**Impact**: High for production - Not secure for mainnet
+**Impact**: High if misconfigured - The mock provider is for tests only
 
-**Status**: Noir circuits planned for v0.2.0
+**Status**: Real ZK proofs are shipped. `NoirProofProvider` (`@sip-protocol/sdk/proofs/noir`) and `BrowserNoirProvider` (`@sip-protocol/sdk/browser`) generate UltraHonk proofs via Barretenberg. Use these for production.
 
-**Recommendation**: Use testnet only until real proofs available.
+**Recommendation**: Use `NoirProofProvider` / `BrowserNoirProvider` in production; the mock provider is restricted to tests and local development.
 
 ### Memory Safety
 
@@ -79,7 +79,7 @@ This document describes the current limitations of SIP Protocol and planned miti
 
 **Impact**: Low - Mitigated by SDK implementation
 
-**Current Implementation** (v0.1.0):
+**Current Implementation** (shipped):
 - `secureWipe()` - Zeroizes Uint8Array buffers immediately after use
 - `withSecureBuffer()` - Auto-cleanup wrapper with guaranteed cleanup
 - `withSecureBufferSync()` - Synchronous version for non-async code
@@ -92,25 +92,15 @@ This document describes the current limitations of SIP Protocol and planned miti
 
 **Recommendation**: Use hardware wallets for high-value operations. SDK handles memory cleanup for cryptographic operations.
 
-### No Hardware Wallet Support
+### Hardware Wallet Support
 
-**Issue**: Hardware wallet signing not implemented.
+**Issue**: High-value users need keys held in dedicated hardware.
 
-**Impact**: Medium - Limits security for high-value users
+**Impact**: Low - Hardware wallet signing is supported
 
-**Status**: Planned for future release
+**Status**: Shipped in M15 - Ledger and Trezor signing plus WalletConnect are supported.
 
-**Recommendation**: Use software wallets with appropriate security practices.
-
-### Single Proof Provider
-
-**Issue**: Only MockProofProvider currently available.
-
-**Impact**: Cannot use in production
-
-**Status**: NoirProofProvider planned
-
-**Recommendation**: Testing and development only.
+**Recommendation**: Use a hardware wallet for high-value operations.
 
 ## Cryptographic Limitations
 
@@ -132,13 +122,13 @@ This document describes the current limitations of SIP Protocol and planned miti
 
 **Recommendation**: Monitor quantum computing developments. Current cryptographic assumptions remain secure for foreseeable future. Plan for migration post-NIST standardization.
 
-### No Trusted Setup... But Mock Proofs
+### No Trusted Setup
 
-**Issue**: While Noir doesn't require trusted setup, mock proofs provide no security.
+**Issue**: Some proving systems require a trusted setup ceremony, which adds a trust assumption.
 
-**Impact**: Security claim doesn't apply until real proofs
+**Impact**: None - SIP avoids this class of risk
 
-**Status**: Real proofs will use universal setup
+**Status**: SIP's Noir circuits compile to UltraHonk (Barretenberg), which uses a universal/updatable setup and requires no circuit-specific trusted setup ceremony.
 
 ### Fixed Generator Construction
 
@@ -178,13 +168,13 @@ This document describes the current limitations of SIP Protocol and planned miti
 
 **Mitigation**: Multi-key encryption supports multiple viewers
 
-### No On-Chain Verification
+### On-Chain Verification Coverage
 
-**Issue**: ZK proofs are verified off-chain by solvers.
+**Issue**: On-chain verification currently covers the funding proof; other proof types are verified off-chain by solvers.
 
-**Impact**: Medium - Requires trust in solver verification
+**Impact**: Low-Medium - Funding proofs are verified on-chain; remaining proof types rely on solver verification
 
-**Status**: On-chain verification planned with real circuits
+**Status**: An on-chain `FundingVerifier` (UltraHonk `HonkVerifier`) is deployed on Sepolia and Arbitrum Sepolia testnets. On-chain verification for the remaining proof types is in progress.
 
 ## Operational Limitations
 
@@ -216,11 +206,13 @@ This document describes the current limitations of SIP Protocol and planned miti
 
 ## Performance Limitations
 
-### Browser Proof Generation (Future)
+### Browser Proof Generation Performance
 
-**Issue**: Proof generation in browser may be slow.
+**Issue**: Proof generation in the browser is computationally intensive and can take a few seconds.
 
-**Expected**: 2-5 seconds per proof
+**Status**: Shipped - `BrowserNoirProvider` (`@sip-protocol/sdk/browser`) generates UltraHonk proofs client-side.
+
+**Expected**: ~2-5 seconds per proof depending on device
 
 **Mitigation**:
 - Web Workers for non-blocking
@@ -240,16 +232,16 @@ This document describes the current limitations of SIP Protocol and planned miti
 
 ## Summary Table
 
-| Limitation | Severity | Status | Timeline |
-|------------|----------|--------|----------|
-| Mock proofs | High | Planned | v0.2.0 |
-| Timing correlation | Medium | Mitigated | v0.1.0 |
-| Amount inference | Medium | Planned | v0.2.0 |
-| Memory safety | Low | Implemented | v0.1.0 |
-| Hardware wallets | Medium | Planned | v0.3.0 |
-| Quantum vulnerability | Low (long-term) | Monitoring | Post-v1.0 |
-| Partial fills | Low | Planned | v0.2.0 |
-| On-chain verification | Medium | Planned | v0.2.0 |
+| Limitation | Severity | Status | Notes |
+|------------|----------|--------|-------|
+| Proof provider misconfiguration | High | Mitigated | Real Noir/UltraHonk providers shipped; mock is test-only |
+| Timing correlation | Medium | Mitigated | Stealth + commitments shipped; batching/delays planned |
+| Amount inference | Medium | Planned | Output range commitments future |
+| Memory safety | Low | Implemented | `secureWipe()` / `withSecureBuffer()` shipped |
+| Hardware wallets | Low | Implemented | Ledger / Trezor / WalletConnect (M15) |
+| Quantum vulnerability | Low (long-term) | Monitoring | Post-NIST standardization |
+| Partial fills | Low | Planned | — |
+| On-chain verification | Low-Medium | Partial | FundingVerifier deployed (Sepolia, Arbitrum Sepolia); other proofs in progress |
 
 ## Reporting Issues
 

--- a/src/content/docs/whitepaper.md
+++ b/src/content/docs/whitepaper.md
@@ -19,7 +19,7 @@ We present SIP (Shielded Intents Protocol), a privacy layer that integrates with
 2. **Stealth addresses** following EIP-5564 to generate unlinkable one-time recipient addresses
 3. **Viewing keys** to enable selective disclosure for compliance requirements
 
-SIP operates as an application layer atop NEAR Intents, requiring no modifications to underlying blockchain infrastructure. Our implementation achieves sub-10ms overhead for privacy operations while maintaining full compatibility with existing multi-chain settlement flows.
+SIP operates as an application layer atop NEAR Intents, requiring no modifications to underlying blockchain infrastructure. Our implementation achieves sub-30ms overhead for privacy operations while maintaining full compatibility with existing multi-chain settlement flows.
 
 ## 1. Introduction
 
@@ -221,7 +221,7 @@ All libraries are Trail of Bits audited with constant-time implementations.
 | Zcash | On-chain privacy; SIP is application layer |
 | Tornado Cash | Fixed denominations; SIP is flexible |
 | Aztec | Requires L2; SIP works on existing chains |
-| Railgun | Single chain; SIP is multi-chain native |
+| Railgun | EVM-only; SIP is multi-chain native |
 
 ## 7. Conclusion
 


### PR DESCRIPTION
## Summary

Re-opens the **PR2 staleness** changes — originally **#108**, which GitHub auto-closed when its base branch was deleted as part of merging #107 (stacked-PR + delete-branch gotcha). #107 is now merged to `main`; this re-targets the same `fix/docs-staleness` branch at `main`. **Identical content** to #108.

Part **2 of 4** of the June 2026 docs audit (#96) — version/status staleness.

## What's refreshed (15 files)
- **changelog** — added 0.7.0 (M15), 0.8.0 (M16–M17 Solana+NEAR same-chain, mainnet-beta), 0.9.0 (M18 EVM); Version History table. Dates from real git tags.
- **roadmap** — M16/M17 ✅ (mainnet live), M18 🔄; tests 6,850 → 7,624+.
- **known-limitations** — corrected the false "proofs are mock / testnet-only / Noir planned" + "no hardware wallet" + "single proof provider" claims (all shipped).
- **security audit docs** — @noble dep versions, test counts, audit timeline (→ Solana Audit Subsidy V, Feb 2026); dated snapshots get caveats.
- **misc** — api-migration version framing; deployment Vercel topology; getting-started Node 18→20; faq @rz1989sol → @sipprotocol; architecture NoirProofProvider → Available; whitepaper sub-30ms + Railgun "EVM-only"; comparison Zcash Halo 2 (Orchard).

Full description + rationale: #108. `astro build` green (1277 pages).

## Series
PR1 (#107, merged) · **PR2 (this, was #108)** · PR3 (#109) · PR4 (#110) → closes #96.

Refs #96
