### PR TITLE
fix(deps): resolve Dependabot security sweep (5 fixed, 2 triaged for dismissal)

### DIFF
--- a/docs/security/DEPENDENCY-AUDIT.md
+++ b/docs/security/DEPENDENCY-AUDIT.md
@@ -1,0 +1,192 @@
+# Dependency Security Audit — docs-sip
+
+| Field | Value |
+|-------|-------|
+| **Document** | DEP-AUDIT-001 (docs-sip) |
+| **Version** | 1.0.0 |
+| **Date** | 2026-06-12 |
+| **Tool** | GitHub Dependabot · `npm audit` · lockfile chain analysis |
+| **Manifest** | `package-lock.json` (root, npm) |
+| **Status** | Active |
+
+## Executive Summary
+
+This document records the triage and resolution of the **7 open Dependabot alerts** on
+`sip-protocol/docs-sip` as of 2026-06-12. All 7 were **development-scope, transitive**
+dependencies in the root `package-lock.json`.
+
+**Outcome: 5 fixed in-tree, 2 recommended for dismissal (both have no upstream patch).**
+
+| Severity | Count | Outcome |
+|----------|-------|---------|
+| High | 2 | ✅ 1 fixed (`langsmith` #64) · 🔍 1 dismissal recommended (`bigint-buffer` #3 — no patch) |
+| Medium | 4 | ✅ All fixed (`langsmith` #61–#63, `uuid` #58) |
+| Low | 1 | 🔍 Dismissal recommended (`elliptic` #60 — no patch) |
+
+### Why every alert is development-scope
+
+`docs-sip` is a static documentation site (Astro 6 + Starlight). `@sip-protocol/sdk` is a
+**devDependency** consumed exclusively by TypeDoc:
+
+- `scripts/generate-api-docs.mjs` runs `npx typedoc`, whose only entry point is
+  `./node_modules/@sip-protocol/sdk/dist/index.d.ts` (see `typedoc.json`).
+- TypeDoc reads **type declarations only** — no SDK runtime code executes during the build,
+  and none is bundled into the published site.
+- Every vulnerable package below sits under the SDK's transitive tree (`@langchain/core`,
+  `@solana/web3.js`, `@solana/spl-token`, `@magicblock-labs/ephemeral-rollups-sdk`). None of
+  that code is ever invoked by the docs build or served to visitors.
+
+The fixes in this audit therefore close *supply-chain hygiene* gaps (clean `npm audit`,
+clean Dependabot dashboard), not live attack surface.
+
+## 1. Disposition at a Glance
+
+| Alert | GHSA | Package | Sev | Vulnerable range | Disposition |
+|-------|------|---------|-----|------------------|-------------|
+| [#64](https://github.com/sip-protocol/docs-sip/security/dependabot/64) | GHSA-3644-q5cj-c5c7 | langsmith | high | < 0.6.0 | ✅ Fixed — override → **0.6.3** |
+| [#63](https://github.com/sip-protocol/docs-sip/security/dependabot/63) | GHSA-rr7j-v2q5-chgv | langsmith | med | <= 0.5.18 | ✅ Fixed — override → **0.6.3** |
+| [#62](https://github.com/sip-protocol/docs-sip/security/dependabot/62) | GHSA-fw9q-39r9-c252 | langsmith | med | <= 0.5.17 | ✅ Fixed — override → **0.6.3** |
+| [#61](https://github.com/sip-protocol/docs-sip/security/dependabot/61) | GHSA-v34v-rq6j-cj6p | langsmith | med | >= 0.3.41 < 0.4.6 | ✅ Fixed — override → **0.6.3** |
+| [#58](https://github.com/sip-protocol/docs-sip/security/dependabot/58) | GHSA-w5hq-g745-h8pq | uuid | med | < 11.1.1 | ✅ Fixed — override → **14.0.0** |
+| [#3](https://github.com/sip-protocol/docs-sip/security/dependabot/3) | GHSA-3gc7-fjrx-p6mg | bigint-buffer | high | <= 1.1.5 (no patch) | 🔍 **Recommend dismiss** (`not_used`) — see §4.1 |
+| [#60](https://github.com/sip-protocol/docs-sip/security/dependabot/60) | GHSA-848j-6mx2-7j84 | elliptic | low | <= 6.6.1 (no patch) | 🔍 **Recommend dismiss** (`not_used`) — see §4.2 |
+
+## 2. Consumer Chains (pre-fix lockfile)
+
+All chains start at the `@sip-protocol/sdk` devDependency:
+
+```
+@sip-protocol/sdk@0.9.0 (devDependency)
+├── @langchain/core@0.3.x (nested)
+│   ├── langsmith@0.3.87        ← alerts #61 #62 #63 #64 (all 4)
+│   └── uuid@10.0.0             ← alert #58
+├── @solana/web3.js@1.98.x
+│   └── jayson@4.x
+│       └── uuid@8.3.2          ← alert #58
+├── @solana/spl-token@0.4.x
+│   └── @solana/buffer-layout-utils@0.2.x
+│       └── bigint-buffer@1.1.5 ← alert #3 (high, no upstream patch)
+└── @magicblock-labs/ephemeral-rollups-sdk
+    └── @phala/dcap-qvl@0.3.9
+        └── elliptic@6.6.1      ← alert #60 (low, no upstream patch)
+```
+
+Note: bumping the SDK alone could not clear the langsmith alerts — `@sip-protocol/sdk@0.11.1`
+still declares `@langchain/core: ^0.3.30`, whose `langsmith: ^0.3.67` range is capped inside
+the vulnerable window. Overrides were required regardless of SDK version.
+
+## 3. Fixes Applied (PR: `fix/dependabot-security-sweep`)
+
+### 3.1 `@sip-protocol/sdk` `^0.9.0` → `^0.11.1`
+
+Routine refresh to the latest published SDK (canonical EIP-5564 release line). Safe here
+because the docs build consumes only `dist/index.d.ts` via TypeDoc; the 0.10.x breaking
+stealth-API changes do not affect type-doc generation. Side benefit: the generated API
+reference (`src/content/docs/reference/`, gitignored, rebuilt on every deploy) now documents
+the current SDK instead of 0.9.0 — the post-bump build emits 1,284 pages vs 1,277.
+
+### 3.2 npm `overrides` added to `package.json`
+
+```json
+"overrides": {
+  "langsmith": "^0.6.0",
+  "uuid": "^14.0.0"
+}
+```
+
+**`langsmith: ^0.6.0`** (clears #61, #62, #63, #64) — resolves to 0.6.3, the first
+release line patched against all four advisories (worst fix floor: 0.6.0 for
+GHSA-3644-q5cj-c5c7). Global override: the `@langchain/core@1.x` / `langchain@1.x`
+consumers declare `>=0.5.0 <1.0.0` (0.6.3 in-range); the nested `@langchain/core@0.3.x`
+consumer declares `^0.3.67` and is force-overridden — acceptable because that code path
+never executes (TypeDoc reads types only). Matches the core repo's `langsmith: >=0.6.0`
+override (sip-protocol DEP-AUDIT-001).
+
+**`uuid: ^14.0.0`** (clears #58) — collapses all uuid instances onto a single patched
+14.0.0 node (14.x is the fixed line for GHSA-w5hq-g745-h8pq). Chosen over `^11.1.1`
+because the production consumer `mermaid` declares `^11.1.0 || ^12 || ^13 || ^14.0.0`
+and already resolved 14.0.0 — this override changes **nothing** for production code.
+The force-upgraded dev consumers (`jayson` `^8.3.2`, `@langchain/core` `^10.0.0`) never
+execute during the docs build. The advisory itself only affects `v3()/v5()/v6()` calls
+with a caller-provided `buf`; these consumers use `v4()` without buffers, so even the
+pre-fix exposure was nil — fixed anyway since patched versions resolve cleanly.
+
+### 3.3 Post-fix lockfile census
+
+```
+langsmith            → 0.6.3   (3 nodes, all patched)
+uuid                 → 14.0.0  (1 node, production, unchanged version)
+bigint-buffer        → 1.1.5   (intentionally retained — see §4.1)
+elliptic             → 6.6.1   (intentionally retained — see §4.2)
+@sip-protocol/sdk    → 0.11.1
+@sip-protocol/types  → 0.2.2
+```
+
+## 4. Dismissal Recommendations
+
+### 4.1 bigint-buffer (#3, high) — recommend `not_used`
+
+- **Advisory:** GHSA-3gc7-fjrx-p6mg / CVE-2025-3194 — `toBigIntLE()` buffer overflow.
+  Impact is **availability only** (application crash; CVSS `C:N/I:N/A:H`) — not memory
+  disclosure or code execution.
+- **No fix exists:** every released version (<= 1.1.5) is affected;
+  `first_patched_version: null`.
+- **Reachability:** consumed via `@solana/spl-token → @solana/buffer-layout-utils`,
+  where it decodes u64 token amounts when **parsing Solana account data at runtime**.
+  The docs build never executes any Solana code path — `@sip-protocol/sdk` is consumed
+  exclusively by TypeDoc as type declarations (see Executive Summary). No input of any kind, let alone
+  attacker-controlled input, ever reaches `toBigIntLE()` in this repository.
+- **Fix path tested and rejected:** the community fork alias
+  (`"bigint-buffer": "npm:bigint-buffer-fixed@^1.1.6"`, as used in the core repo's pnpm
+  overrides) was applied and verified during this sweep, then **reverted**: the fork
+  declares `node-gyp@^9.4.1` as a *runtime* dependency, which dragged
+  `node-gyp@9.4.1`, `tar@6.2.1`, `cacache@16.1.3`, and `make-fetch-happen@10.2.1` into
+  the lockfile — four packages currently carrying **high-severity advisories** of their
+  own (including the node-tar hardlink/symlink path-traversal set affecting `<= 7.5.10`),
+  and node-gyp *does* execute during every `npm ci` via the fork's install script.
+  Trading one unreachable HIGH for four new HIGHs (one of which runs at install time)
+  is net-negative; dismissal is the honest disposition.
+- **Precedent:** `sip-protocol/sip-protocol` adopted the fork alias when its tar/node-gyp
+  chain was still clean; with the newer node-tar advisories that trade-off no longer holds
+  for a fresh lockfile.
+
+### 4.2 elliptic (#60, low) — recommend `not_used`
+
+- **Advisory:** GHSA-848j-6mx2-7j84 / CVE-2025-14505 — ECDSA **signature generation**
+  produces faulty signatures when an interim RFC 6979 `k` value has leading zeros;
+  paired faulty+correct signatures over the same input can leak the signing key.
+- **No fix exists:** every released version (<= 6.6.1) is affected;
+  `first_patched_version: null`. There is no upgrade or fork to move to.
+- **Reachability:** sole consumer is `@phala/dcap-qvl` (Intel SGX/TDX DCAP quote
+  verification, via `@magicblock-labs/ephemeral-rollups-sdk` — still present in the
+  SDK 0.11.1 tree). Quote verification **verifies** ECDSA signatures over supplied
+  quotes — it never **signs**, so the vulnerable signing path is unreachable and no
+  private key exists in this process to leak. And as with §4.1, none of this code
+  executes in the docs build at all.
+- **Precedent:** `sip-protocol/sip-protocol` dismissed this same advisory as `not_used`
+  in its 2026-06-06 audit (core DEP-AUDIT-001 §2.2) on identical verify-only reasoning.
+
+Both dismissals are reversible at any time via the Dependabot UI or API if patched
+releases ever appear.
+
+## 5. Verification
+
+| Gate | Before (SDK 0.9.0) | After (SDK 0.11.1 + overrides) |
+|------|--------------------|--------------------------------|
+| Fresh `npm ci` (npm 10) | ✅ pass | ✅ pass |
+| `npm run build` (TypeDoc + Astro) | ✅ pass (1,277 pages) | ✅ pass (1,284 pages) |
+| Vulnerable langsmith/uuid nodes | 3 (0.3.87, 8.3.2, 10.0.0) | **0** |
+| Unpatchable nodes retained | bigint-buffer 1.1.5 · elliptic 6.6.1 | same (dismissal recommended) |
+
+### Lockfile maintenance policy (important)
+
+CI (`docs-validate.yml`, `deploy.yml`) runs `npm ci` on **Node 22 / npm 10**. npm 11
+(bundled with Node 24) omits optional-dependency lockfile nodes that npm 10's `npm ci`
+requires, producing `Missing X from lock file` failures. **Always regenerate
+`package-lock.json` with `npx -y npm@10 install`** and avoid running lockfile-mutating
+npm 11 commands afterwards.
+
+---
+
+*Maintained alongside Dependabot. Update this document whenever alerts are fixed,
+dismissed, or newly triaged.*

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "sharp": "^0.34.2"
       },
       "devDependencies": {
-        "@sip-protocol/sdk": "^0.9.0",
+        "@sip-protocol/sdk": "^0.11.1",
         "@sip-protocol/types": "^0.2.1",
         "typedoc": "^0.28.16",
         "typedoc-plugin-markdown": "^4.4.0"
@@ -1478,6 +1478,41 @@
         "node": ">=20"
       }
     },
+    "node_modules/@langchain/core/node_modules/langsmith": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.6.3.tgz",
+      "integrity": "sha512-pXrQ4/4myQvjFFOAUmt5pWRrLEZR20gzIJD7MNdUH+5/S5nLI4ZRBo/SYKC6coaYj9pYTfQdBIzcs+3kfJ5uDA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "p-queue": "6.6.2"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*",
+        "ws": ">=7"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@langchain/langgraph": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.3.4.tgz",
@@ -1601,12 +1636,14 @@
       "license": "MIT"
     },
     "node_modules/@magicblock-labs/ephemeral-rollups-sdk": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@magicblock-labs/ephemeral-rollups-sdk/-/ephemeral-rollups-sdk-0.8.8.tgz",
-      "integrity": "sha512-qrhZXSjt4lY3io6pY/VTVkNj2FYGSu/uNwNuT6g3WUFvBVK9pH+enWQHEMSk/f9MsqRbn+prBPCYYVo+1QKMUA==",
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/@magicblock-labs/ephemeral-rollups-sdk/-/ephemeral-rollups-sdk-0.14.4.tgz",
+      "integrity": "sha512-Wmy1Th3OIbIvSLUHAafEOytF+y8JgK//gipJiYcZcgwIbIUkHDDlrtN31KNvDcvm548/GV+nDuqe56sN3TDcJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@noble/curves": "^1.4.2",
+        "@noble/hashes": "^1.4.0",
         "@phala/dcap-qvl": "^0.3.9",
         "@solana/web3.js": "^1.98.0",
         "bs58": "^6.0.0",
@@ -1928,27 +1965,27 @@
       ]
     },
     "node_modules/@peculiar/asn1-schema": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
-      "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/utils": "^2.0.2",
-        "asn1js": "^3.0.6",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-x509": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.7.0.tgz",
-      "integrity": "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+      "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.8.0",
         "@peculiar/utils": "^2.0.2",
-        "asn1js": "^3.0.6",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
@@ -2628,38 +2665,38 @@
       "license": "MIT"
     },
     "node_modules/@sip-protocol/sdk": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@sip-protocol/sdk/-/sdk-0.9.0.tgz",
-      "integrity": "sha512-bFYraBIg5sOYDBXEDMU09/T+mGVm32XOz1NlPnOJmXWe0VznfZzSQo4JIOkpdzGYUhl9M8HxJo/0JNnNq66Ptg==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@sip-protocol/sdk/-/sdk-0.11.1.tgz",
+      "integrity": "sha512-Bht9fkCN1R994TjRbDFCfBeyhv1O9EjUa9tWG3ifZGt25h6kVnm5N6IV/HhMbgqwq+r/XwYW0l7egFhswT88tg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@aztec/bb.js": "3.0.2",
-        "@ethereumjs/rlp": "^10.1.0",
+        "@ethereumjs/rlp": "^10.1.2",
         "@jup-ag/api": "^6.0.48",
         "@langchain/core": "^0.3.30",
         "@langchain/openai": "^0.4.2",
-        "@magicblock-labs/ephemeral-rollups-sdk": "^0.8.5",
-        "@noble/ciphers": "^2.1.1",
+        "@magicblock-labs/ephemeral-rollups-sdk": "^0.14.4",
+        "@noble/ciphers": "^2.2.0",
         "@noble/curves": "^1.3.0",
         "@noble/hashes": "^1.3.3",
         "@noir-lang/noir_js": "1.0.0-beta.18",
         "@noir-lang/types": "1.0.0-beta.18",
-        "@radr/shadowwire": "^1.1.2",
-        "@scure/base": "^2.0.0",
-        "@scure/bip32": "^2.0.1",
-        "@scure/bip39": "^2.0.1",
+        "@radr/shadowwire": "^1.1.15",
+        "@scure/base": "^2.2.0",
+        "@scure/bip32": "^2.2.0",
+        "@scure/bip39": "^2.2.0",
         "@sip-protocol/types": "^0.2.2",
-        "@solana-program/compute-budget": "^0.11.0",
-        "@solana-program/system": "^0.10.0",
+        "@solana-program/compute-budget": "^0.15.0",
+        "@solana-program/system": "^0.12.2",
         "@solana/compat": "^5.4.0",
         "@solana/kit": "^5.4.0",
         "@solana/spl-token": "^0.4.14",
         "@solana/web3.js": "^1.98.4",
         "@triton-one/yellowstone-grpc": "^4.0.2",
-        "langchain": "^1.2.10",
-        "pino": "^10.2.0",
-        "zod": "^4.3.5"
+        "langchain": "^1.4.4",
+        "pino": "^10.3.1",
+        "zod": "^4.4.3"
       },
       "optionalDependencies": {
         "https-proxy-agent": "^7.0.0",
@@ -2691,24 +2728,20 @@
       }
     },
     "node_modules/@sip-protocol/sdk/node_modules/@langchain/core/node_modules/langsmith": {
-      "version": "0.3.87",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.87.tgz",
-      "integrity": "sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.6.3.tgz",
+      "integrity": "sha512-pXrQ4/4myQvjFFOAUmt5pWRrLEZR20gzIJD7MNdUH+5/S5nLI4ZRBo/SYKC6coaYj9pYTfQdBIzcs+3kfJ5uDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/uuid": "^10.0.0",
-        "chalk": "^4.1.2",
-        "console-table-printer": "^2.12.1",
-        "p-queue": "^6.6.2",
-        "semver": "^7.6.3",
-        "uuid": "^10.0.0"
+        "p-queue": "6.6.2"
       },
       "peerDependencies": {
         "@opentelemetry/api": "*",
         "@opentelemetry/exporter-trace-otlp-proto": "*",
         "@opentelemetry/sdk-trace-base": "*",
-        "openai": "*"
+        "openai": "*",
+        "ws": ">=7"
       },
       "peerDependenciesMeta": {
         "@opentelemetry/api": {
@@ -2721,6 +2754,9 @@
           "optional": true
         },
         "openai": {
+          "optional": true
+        },
+        "ws": {
           "optional": true
         }
       }
@@ -2795,6 +2831,639 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/accounts": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-5.5.1.tgz",
+      "integrity": "sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/codecs": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-5.5.1.tgz",
+      "integrity": "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/options": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/fast-stable-stringify": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-5.5.1.tgz",
+      "integrity": "sha512-Ni7s2FN33zTzhTFgRjEbOVFO+UAmK8qi3Iu0/GRFYK4jN696OjKHnboSQH/EacQ+yGqS54bfxf409wU5dsLLCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/instruction-plans": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-5.5.1.tgz",
+      "integrity": "sha512-7z3CB7YMcFKuVvgcnNY8bY6IsZ8LG61Iytbz7HpNVGX2u1RthOs1tRW8luTzSG1MPL0Ox7afyAVMYeFqSPHnaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/kit": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.5.1.tgz",
+      "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "5.5.1",
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/instruction-plans": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/offchain-messages": "5.5.1",
+        "@solana/plugin-core": "5.5.1",
+        "@solana/programs": "5.5.1",
+        "@solana/rpc": "5.5.1",
+        "@solana/rpc-api": "5.5.1",
+        "@solana/rpc-parsed-types": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-subscriptions": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/signers": "5.5.1",
+        "@solana/sysvars": "5.5.1",
+        "@solana/transaction-confirmation": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/offchain-messages": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-5.5.1.tgz",
+      "integrity": "sha512-g+xHH95prTU+KujtbOzj8wn+C7ZNoiLhf3hj6nYq3MTyxOXtBEysguc97jJveUZG0K97aIKG6xVUlMutg5yxhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/options": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-5.5.1.tgz",
+      "integrity": "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/plugin-core": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-5.5.1.tgz",
+      "integrity": "sha512-VUZl30lDQFJeiSyNfzU1EjYt2QZvoBFKEwjn1lilUJw7KgqD5z7mbV7diJhT+dLFs36i0OsjXvq5kSygn8YJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/programs": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-5.5.1.tgz",
+      "integrity": "sha512-7U9kn0Jsx1NuBLn5HRTFYh78MV4XN145Yc3WP/q5BlqAVNlMoU9coG5IUTJIG847TUqC1lRto3Dnpwm6T4YRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/promises": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-5.5.1.tgz",
+      "integrity": "sha512-T9lfuUYkGykJmppEcssNiCf6yiYQxJkhiLPP+pyAc2z84/7r3UVIb2tNJk4A9sucS66pzJnVHZKcZVGUUp6wzA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/rpc": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-5.5.1.tgz",
+      "integrity": "sha512-ku8zTUMrkCWci66PRIBC+1mXepEnZH/q1f3ck0kJZ95a06bOTl5KU7HeXWtskkyefzARJ5zvCs54AD5nxjQJ+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/fast-stable-stringify": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/rpc-api": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-transport-http": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/rpc-api": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-5.5.1.tgz",
+      "integrity": "sha512-XWOQQPhKl06Vj0xi3RYHAc6oEQd8B82okYJ04K7N0Vvy3J4PN2cxeK7klwkjgavdcN9EVkYCChm2ADAtnztKnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/rpc-parsed-types": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/rpc-parsed-types": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-5.5.1.tgz",
+      "integrity": "sha512-HEi3G2nZqGEsa3vX6U0FrXLaqnUCg4SKIUrOe8CezD+cSFbRTOn3rCLrUmJrhVyXlHoQVaRO9mmeovk31jWxJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/rpc-spec": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-5.5.1.tgz",
+      "integrity": "sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/rpc-spec-types": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-5.5.1.tgz",
+      "integrity": "sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/rpc-subscriptions": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-5.5.1.tgz",
+      "integrity": "sha512-CTMy5bt/6mDh4tc6vUJms9EcuZj3xvK0/xq8IQ90rhkpYvate91RjBP+egvjgSayUg9yucU9vNuUpEjz4spM7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/fast-stable-stringify": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-subscriptions-api": "5.5.1",
+        "@solana/rpc-subscriptions-channel-websocket": "5.5.1",
+        "@solana/rpc-subscriptions-spec": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/subscribable": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/rpc-subscriptions-api": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-5.5.1.tgz",
+      "integrity": "sha512-5Oi7k+GdeS8xR2ly1iuSFkAv6CZqwG0Z6b1QZKbEgxadE1XGSDrhM2cn59l+bqCozUWCqh4c/A2znU/qQjROlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/rpc-subscriptions-spec": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-5.5.1.tgz",
+      "integrity": "sha512-7tGfBBrYY8TrngOyxSHoCU5shy86iA9SRMRrPSyBhEaZRAk6dnbdpmUTez7gtdVo0BCvh9nzQtUycKWSS7PnFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/rpc-subscriptions-spec": "5.5.1",
+        "@solana/subscribable": "5.5.1",
+        "ws": "^8.19.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-5.5.1.tgz",
+      "integrity": "sha512-iq+rGq5fMKP3/mKHPNB6MC8IbVW41KGZg83Us/+LE3AWOTWV1WT20KT2iH1F1ik9roi42COv/TpoZZvhKj45XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/subscribable": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/rpc-transformers": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-5.5.1.tgz",
+      "integrity": "sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/rpc-transport-http": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-5.5.1.tgz",
+      "integrity": "sha512-yv8GoVSHqEV0kUJEIhkdOVkR2SvJ6yoWC51cJn2rSV7plr6huLGe0JgujCmB7uZhhaLbcbP3zxXxu9sOjsi7Fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "undici-types": "^7.19.2"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/rpc-transport-http/node_modules/undici-types": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.27.2.tgz",
+      "integrity": "sha512-cH9f42mHuljpNuoS47sWDDWXVxWnJgYCzHVUlr3tn7+HVx0L6QSO+VG5qgzT4kXkR2K8ZsReaT5bupam6RNAEQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/signers": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-5.5.1.tgz",
+      "integrity": "sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/offchain-messages": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/subscribable": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-5.5.1.tgz",
+      "integrity": "sha512-9K0PsynFq0CsmK1CDi5Y2vUIJpCqkgSS5yfDN0eKPgHqEptLEaia09Kaxc90cSZDZU5mKY/zv1NBmB6Aro9zQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/sysvars": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-5.5.1.tgz",
+      "integrity": "sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "5.5.1",
+        "@solana/codecs": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sip-protocol/sdk/node_modules/@solana/transaction-confirmation": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-5.5.1.tgz",
+      "integrity": "sha512-j4mKlYPHEyu+OD7MBt3jRoX4ScFgkhZC6H65on4Fux6LMScgivPJlwnKoZMnsgxFgWds0pl+BYzSiALDsXlYtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/rpc": "5.5.1",
+        "@solana/rpc-subscriptions": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@sip-protocol/sdk/node_modules/@types/node": {
       "version": "18.19.130",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
@@ -2813,39 +3482,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@sip-protocol/sdk/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@sip-protocol/sdk/node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -2872,21 +3508,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@sip-protocol/sdk/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@sip-protocol/types": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@sip-protocol/types/-/types-0.2.2.tgz",
@@ -2895,49 +3516,255 @@
       "license": "MIT"
     },
     "node_modules/@solana-program/compute-budget": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@solana-program/compute-budget/-/compute-budget-0.11.0.tgz",
-      "integrity": "sha512-7f1ePqB/eURkTwTOO9TNIdUXZcyrZoX3Uy2hNo7cXMfNhPFWp9AVgIyRNBc2jf15sdUa9gNpW+PfP2iV8AYAaw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/compute-budget/-/compute-budget-0.15.0.tgz",
+      "integrity": "sha512-toejNdIkzpUTqLSIzP0Nofr/EFel8QpPWuTtIKzfCcjn+mXpkThHxPJaNesk251rSTiWaxDZ3WxG7RxYwTWTqA==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@solana/kit": "^5.0"
+        "@solana/kit": "^6.3.0"
       }
     },
     "node_modules/@solana-program/system": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.10.0.tgz",
-      "integrity": "sha512-Go+LOEZmqmNlfr+Gjy5ZWAdY5HbYzk2RBewD9QinEU/bBSzpFfzqDRT55JjFRBGJUvMgf3C2vfXEGT4i8DSI4g==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.12.2.tgz",
+      "integrity": "sha512-MaBeOxlvTruQhA7UYkOb3hVTEHPPagOtd+PvTm6a8rGgvEAP0kD4BbC37NceOaR4ABNqdaCmD5OMVRKgrE6KAg==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@solana/kit": "^5.0"
+        "@solana/kit": "^6.4.0"
       }
     },
     "node_modules/@solana/accounts": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-5.5.1.tgz",
-      "integrity": "sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-6.9.0.tgz",
+      "integrity": "sha512-g36AJreJrgf9AAjOfbdFHEFUTymBgzbWHoEDElZ+fDKvqBINDiUVKzDApwc7C7kGPMFqQBaoEHnQRxf2IqfKZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/rpc-spec": "5.5.1",
-        "@solana/rpc-types": "5.5.1"
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/rpc-spec": "6.9.0",
+        "@solana/rpc-types": "6.9.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/addresses": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.9.0.tgz",
+      "integrity": "sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/assertions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.9.0.tgz",
+      "integrity": "sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/codecs-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
+      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/codecs-numbers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
+      "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/codecs-strings": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
+      "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/nominal-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.9.0.tgz",
+      "integrity": "sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/rpc-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.9.0.tgz",
+      "integrity": "sha512-iFhPzZK3qiQ1lhfNTNBTI7BIs5PfWZSgRLD3enKm8ZAQggzvUklfO3KPh47jVsc/Jsr1UGPH8M3o3m17qjO1Cg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/fixed-points": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@solana/addresses": {
@@ -3016,23 +3843,25 @@
       }
     },
     "node_modules/@solana/codecs": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-5.5.1.tgz",
-      "integrity": "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-6.9.0.tgz",
+      "integrity": "sha512-oWOybKa1PTGI1D/FyrvGKralADM1jmVZC2AtgEo+4JTKG0+i1p9ZbwNY2UcJqdYsDMDaGHAx0LMAid9LDCxXTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-data-structures": "5.5.1",
-        "@solana/codecs-numbers": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/options": "5.5.1"
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/fixed-points": "6.9.0",
+        "@solana/options": "6.9.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3133,6 +3962,140 @@
         }
       }
     },
+    "node_modules/@solana/codecs/node_modules/@solana/codecs-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
+      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/@solana/codecs-data-structures": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.9.0.tgz",
+      "integrity": "sha512-f7GYtiHafvJDhqiwzUUSr/6AYSK4DCw6quPmA80NZGtkNiFa+g6LoJy2wbC0wp2dxvCwNpxf6x3ILCYRutAvvg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/@solana/codecs-numbers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
+      "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/@solana/codecs-strings": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
+      "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@solana/compat": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/compat/-/compat-5.5.1.tgz",
@@ -3195,21 +4158,104 @@
       }
     },
     "node_modules/@solana/fast-stable-stringify": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-5.5.1.tgz",
-      "integrity": "sha512-Ni7s2FN33zTzhTFgRjEbOVFO+UAmK8qi3Iu0/GRFYK4jN696OjKHnboSQH/EacQ+yGqS54bfxf409wU5dsLLCw==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-6.9.0.tgz",
+      "integrity": "sha512-l14zGVsURbT5Aox/kLFQywqV4VaE9/j3h2EvCu9oULVPMwzQB6yezJb1/KyiDwhm/RscooPd0gFQFIKEGQbayw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/fixed-points": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/fixed-points/-/fixed-points-6.9.0.tgz",
+      "integrity": "sha512-0K7mbYC4jdAZFlXqXjpNanmEyZxk7K9NtXDLc1zuhGuxwH8J9guvohwdw2V7TQ9bfjCYsprY3Tp2kUVQpECGmA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/fixed-points/node_modules/@solana/codecs-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
+      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/fixed-points/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/fixed-points/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@solana/functional": {
@@ -3231,29 +4277,391 @@
       }
     },
     "node_modules/@solana/instruction-plans": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-5.5.1.tgz",
-      "integrity": "sha512-7z3CB7YMcFKuVvgcnNY8bY6IsZ8LG61Iytbz7HpNVGX2u1RthOs1tRW8luTzSG1MPL0Ox7afyAVMYeFqSPHnaQ==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-6.9.0.tgz",
+      "integrity": "sha512-SxTSOetEKD+WPzvDuYRsP1+KkwUp8KqL1n7oFx9ThxjyfEY0ly0i9KdbvX5yYVDOA2TSwrltgdu14y/Pf6y3Cg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@solana/errors": "5.5.1",
-        "@solana/instructions": "5.5.1",
-        "@solana/keys": "5.5.1",
-        "@solana/promises": "5.5.1",
-        "@solana/transaction-messages": "5.5.1",
-        "@solana/transactions": "5.5.1"
+        "@solana/errors": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/promises": "6.9.0",
+        "@solana/transaction-messages": "6.9.0",
+        "@solana/transactions": "6.9.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/addresses": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.9.0.tgz",
+      "integrity": "sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/assertions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.9.0.tgz",
+      "integrity": "sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/codecs-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
+      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/codecs-data-structures": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.9.0.tgz",
+      "integrity": "sha512-f7GYtiHafvJDhqiwzUUSr/6AYSK4DCw6quPmA80NZGtkNiFa+g6LoJy2wbC0wp2dxvCwNpxf6x3ILCYRutAvvg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/codecs-numbers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
+      "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/codecs-strings": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
+      "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/functional": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.9.0.tgz",
+      "integrity": "sha512-sgNHOaIjETZZuziZdlwPsU5EjBVj5M0dUbwrSQTTNZe0SxX3pQ1QFVcs5KyvdS7AQcpBVdLjx4CfQjdKXk52GA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/instructions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.9.0.tgz",
+      "integrity": "sha512-LZfJx3bGdUSbGaswoOEPHygticqkCg3TusRczPJXyCmKhoQzPCcGQQ99qMzP7Wg8pEV5tWA5t7tycf8E237ydg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/keys": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.9.0.tgz",
+      "integrity": "sha512-1g2QARiqSjNqT0EIqLDLQ5vRm7hCsbqgFwFAp5GsMV/8BTYT8s1Ct2wLHDZiJ4eAX6beTHVf8LbOBfVejtn3oQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/promises": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/nominal-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.9.0.tgz",
+      "integrity": "sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/rpc-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.9.0.tgz",
+      "integrity": "sha512-iFhPzZK3qiQ1lhfNTNBTI7BIs5PfWZSgRLD3enKm8ZAQggzvUklfO3KPh47jVsc/Jsr1UGPH8M3o3m17qjO1Cg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/fixed-points": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/transaction-messages": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.9.0.tgz",
+      "integrity": "sha512-OWpryt0w6SHlwHx12Vd1wvx2QwSGBXAIUEHTCtkctcM3AaZRy5cIl7CAq9iD5PgahUsaOyRLBV0zlCJcC2JrJA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/rpc-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/transactions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.9.0.tgz",
+      "integrity": "sha512-uKPzLwHbjwChfVl82he17ntkh02PfgnMMhN7uOAC+VbkIt1O+EEw8sX87gi6kdG/EV+QBDQXm9PLAo5W0tYylw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/transaction-messages": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@solana/instructions": {
@@ -3304,45 +4712,410 @@
       }
     },
     "node_modules/@solana/kit": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.5.1.tgz",
-      "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-6.9.0.tgz",
+      "integrity": "sha512-k7BRz7Akfv8wiRtlCR/xUyDLfuMfYMelMR1+AC5KgwaRRJReDF0BucMLNN1In7WoI+KuWwr1OKv4na/oKpyeAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@solana/accounts": "5.5.1",
-        "@solana/addresses": "5.5.1",
-        "@solana/codecs": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/functional": "5.5.1",
-        "@solana/instruction-plans": "5.5.1",
-        "@solana/instructions": "5.5.1",
-        "@solana/keys": "5.5.1",
-        "@solana/offchain-messages": "5.5.1",
-        "@solana/plugin-core": "5.5.1",
-        "@solana/programs": "5.5.1",
-        "@solana/rpc": "5.5.1",
-        "@solana/rpc-api": "5.5.1",
-        "@solana/rpc-parsed-types": "5.5.1",
-        "@solana/rpc-spec-types": "5.5.1",
-        "@solana/rpc-subscriptions": "5.5.1",
-        "@solana/rpc-types": "5.5.1",
-        "@solana/signers": "5.5.1",
-        "@solana/sysvars": "5.5.1",
-        "@solana/transaction-confirmation": "5.5.1",
-        "@solana/transaction-messages": "5.5.1",
-        "@solana/transactions": "5.5.1"
+        "@solana/accounts": "6.9.0",
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/instruction-plans": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/offchain-messages": "6.9.0",
+        "@solana/plugin-core": "6.9.0",
+        "@solana/plugin-interfaces": "6.9.0",
+        "@solana/program-client-core": "6.9.0",
+        "@solana/programs": "6.9.0",
+        "@solana/rpc": "6.9.0",
+        "@solana/rpc-api": "6.9.0",
+        "@solana/rpc-parsed-types": "6.9.0",
+        "@solana/rpc-spec-types": "6.9.0",
+        "@solana/rpc-subscriptions": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/signers": "6.9.0",
+        "@solana/subscribable": "6.9.0",
+        "@solana/sysvars": "6.9.0",
+        "@solana/transaction-confirmation": "6.9.0",
+        "@solana/transaction-messages": "6.9.0",
+        "@solana/transactions": "6.9.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/addresses": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.9.0.tgz",
+      "integrity": "sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/assertions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.9.0.tgz",
+      "integrity": "sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/codecs-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
+      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/codecs-data-structures": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.9.0.tgz",
+      "integrity": "sha512-f7GYtiHafvJDhqiwzUUSr/6AYSK4DCw6quPmA80NZGtkNiFa+g6LoJy2wbC0wp2dxvCwNpxf6x3ILCYRutAvvg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/codecs-numbers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
+      "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/codecs-strings": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
+      "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/functional": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.9.0.tgz",
+      "integrity": "sha512-sgNHOaIjETZZuziZdlwPsU5EjBVj5M0dUbwrSQTTNZe0SxX3pQ1QFVcs5KyvdS7AQcpBVdLjx4CfQjdKXk52GA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/instructions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.9.0.tgz",
+      "integrity": "sha512-LZfJx3bGdUSbGaswoOEPHygticqkCg3TusRczPJXyCmKhoQzPCcGQQ99qMzP7Wg8pEV5tWA5t7tycf8E237ydg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/keys": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.9.0.tgz",
+      "integrity": "sha512-1g2QARiqSjNqT0EIqLDLQ5vRm7hCsbqgFwFAp5GsMV/8BTYT8s1Ct2wLHDZiJ4eAX6beTHVf8LbOBfVejtn3oQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/promises": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/nominal-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.9.0.tgz",
+      "integrity": "sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/rpc-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.9.0.tgz",
+      "integrity": "sha512-iFhPzZK3qiQ1lhfNTNBTI7BIs5PfWZSgRLD3enKm8ZAQggzvUklfO3KPh47jVsc/Jsr1UGPH8M3o3m17qjO1Cg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/fixed-points": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/transaction-messages": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.9.0.tgz",
+      "integrity": "sha512-OWpryt0w6SHlwHx12Vd1wvx2QwSGBXAIUEHTCtkctcM3AaZRy5cIl7CAq9iD5PgahUsaOyRLBV0zlCJcC2JrJA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/rpc-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/transactions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.9.0.tgz",
+      "integrity": "sha512-uKPzLwHbjwChfVl82he17ntkh02PfgnMMhN7uOAC+VbkIt1O+EEw8sX87gi6kdG/EV+QBDQXm9PLAo5W0tYylw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/transaction-messages": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@solana/nominal-types": {
@@ -3364,91 +5137,947 @@
       }
     },
     "node_modules/@solana/offchain-messages": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-5.5.1.tgz",
-      "integrity": "sha512-g+xHH95prTU+KujtbOzj8wn+C7ZNoiLhf3hj6nYq3MTyxOXtBEysguc97jJveUZG0K97aIKG6xVUlMutg5yxhw==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-6.9.0.tgz",
+      "integrity": "sha512-qK3tqRPb+E0kmTz5qFXZbEdF4pyzfOWRZjyVESHVGemDDeGzZ1SV3zAxcA6HBCnv4wCBnlyaDPw8t+5sryNMAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-data-structures": "5.5.1",
-        "@solana/codecs-numbers": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/keys": "5.5.1",
-        "@solana/nominal-types": "5.5.1"
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/addresses": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.9.0.tgz",
+      "integrity": "sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/assertions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.9.0.tgz",
+      "integrity": "sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/codecs-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
+      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/codecs-data-structures": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.9.0.tgz",
+      "integrity": "sha512-f7GYtiHafvJDhqiwzUUSr/6AYSK4DCw6quPmA80NZGtkNiFa+g6LoJy2wbC0wp2dxvCwNpxf6x3ILCYRutAvvg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/codecs-numbers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
+      "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/codecs-strings": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
+      "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/keys": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.9.0.tgz",
+      "integrity": "sha512-1g2QARiqSjNqT0EIqLDLQ5vRm7hCsbqgFwFAp5GsMV/8BTYT8s1Ct2wLHDZiJ4eAX6beTHVf8LbOBfVejtn3oQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/promises": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/nominal-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.9.0.tgz",
+      "integrity": "sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@solana/options": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/options/-/options-5.5.1.tgz",
-      "integrity": "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-6.9.0.tgz",
+      "integrity": "sha512-H5ZRWNzzLMwHU/fRU9aVx+3TaMN4gDNCUYxsZxq0h7mqiwxFy6mpy95xPsfdldthCHDYtYnUTxe2sBatGbNHig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-data-structures": "5.5.1",
-        "@solana/codecs-numbers": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/errors": "5.5.1"
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/options/node_modules/@solana/codecs-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
+      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options/node_modules/@solana/codecs-data-structures": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.9.0.tgz",
+      "integrity": "sha512-f7GYtiHafvJDhqiwzUUSr/6AYSK4DCw6quPmA80NZGtkNiFa+g6LoJy2wbC0wp2dxvCwNpxf6x3ILCYRutAvvg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options/node_modules/@solana/codecs-numbers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
+      "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options/node_modules/@solana/codecs-strings": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
+      "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@solana/plugin-core": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-5.5.1.tgz",
-      "integrity": "sha512-VUZl30lDQFJeiSyNfzU1EjYt2QZvoBFKEwjn1lilUJw7KgqD5z7mbV7diJhT+dLFs36i0OsjXvq5kSygn8YJ3A==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-6.9.0.tgz",
+      "integrity": "sha512-KslLSnzY8zbGZibEBVMVUm2ZS8T2xf+cut7F65VjWPoWNAxU+p7933wsMz/az6CF7b65RI7iU3HhCr5/5QF50w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-interfaces/-/plugin-interfaces-6.9.0.tgz",
+      "integrity": "sha512-Qj4sk9thkM1UgnFXvWIoezd/CbqpX/2jigLBDsMB5Ed/gmFlkBSTL127LFDSY3OtzBpXl4hROs+Zqv+5xqtguA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/instruction-plans": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/rpc-spec": "6.9.0",
+        "@solana/rpc-subscriptions-spec": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/signers": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/addresses": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.9.0.tgz",
+      "integrity": "sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/assertions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.9.0.tgz",
+      "integrity": "sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/codecs-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
+      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/codecs-numbers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
+      "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/codecs-strings": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
+      "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/keys": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.9.0.tgz",
+      "integrity": "sha512-1g2QARiqSjNqT0EIqLDLQ5vRm7hCsbqgFwFAp5GsMV/8BTYT8s1Ct2wLHDZiJ4eAX6beTHVf8LbOBfVejtn3oQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/promises": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/nominal-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.9.0.tgz",
+      "integrity": "sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/@solana/rpc-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.9.0.tgz",
+      "integrity": "sha512-iFhPzZK3qiQ1lhfNTNBTI7BIs5PfWZSgRLD3enKm8ZAQggzvUklfO3KPh47jVsc/Jsr1UGPH8M3o3m17qjO1Cg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/fixed-points": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@solana/program-client-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/program-client-core/-/program-client-core-6.9.0.tgz",
+      "integrity": "sha512-+iUnsddhs72QoBJoUO+/yHUXoBvYWa1sGCBRJk35zeg8j7ZXEwRkk6eX0VOrUPxhEpQbYJsIOCrIYApNIt8RFw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/accounts": "6.9.0",
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/instruction-plans": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/plugin-interfaces": "6.9.0",
+        "@solana/rpc-api": "6.9.0",
+        "@solana/signers": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/addresses": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.9.0.tgz",
+      "integrity": "sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/assertions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.9.0.tgz",
+      "integrity": "sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/codecs-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
+      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/codecs-numbers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
+      "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/codecs-strings": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
+      "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/instructions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.9.0.tgz",
+      "integrity": "sha512-LZfJx3bGdUSbGaswoOEPHygticqkCg3TusRczPJXyCmKhoQzPCcGQQ99qMzP7Wg8pEV5tWA5t7tycf8E237ydg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/nominal-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.9.0.tgz",
+      "integrity": "sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@solana/programs": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-5.5.1.tgz",
-      "integrity": "sha512-7U9kn0Jsx1NuBLn5HRTFYh78MV4XN145Yc3WP/q5BlqAVNlMoU9coG5IUTJIG847TUqC1lRto3Dnpwm6T4YRpA==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-6.9.0.tgz",
+      "integrity": "sha512-L9LAnQtfFFcCDLcbbnxhUtgAmu/kS4aRmrVncdnX5CFyQshlpo0/Qhrq3UA7vnhute4gjYV4pFT+64onH5qGEQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/errors": "5.5.1"
+        "@solana/addresses": "6.9.0",
+        "@solana/errors": "6.9.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3456,17 +6085,195 @@
         }
       }
     },
-    "node_modules/@solana/promises": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-5.5.1.tgz",
-      "integrity": "sha512-T9lfuUYkGykJmppEcssNiCf6yiYQxJkhiLPP+pyAc2z84/7r3UVIb2tNJk4A9sucS66pzJnVHZKcZVGUUp6wzA==",
+    "node_modules/@solana/programs/node_modules/@solana/addresses": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.9.0.tgz",
+      "integrity": "sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/@solana/assertions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.9.0.tgz",
+      "integrity": "sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/@solana/codecs-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
+      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/@solana/codecs-numbers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
+      "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/@solana/codecs-strings": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
+      "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/@solana/nominal-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.9.0.tgz",
+      "integrity": "sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@solana/promises": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-6.9.0.tgz",
+      "integrity": "sha512-227PlXRi6KZX4ODYTkJitr9InSa79NTquI72slay4gzxO9VmMepgvYdMAX6kawdN5pt+VzaklKhNhWXk50Pi9g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3475,27 +6282,28 @@
       }
     },
     "node_modules/@solana/rpc": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-5.5.1.tgz",
-      "integrity": "sha512-ku8zTUMrkCWci66PRIBC+1mXepEnZH/q1f3ck0kJZ95a06bOTl5KU7HeXWtskkyefzARJ5zvCs54AD5nxjQJ+A==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-6.9.0.tgz",
+      "integrity": "sha512-ny1Kt20+oq3xZErNA56+Magmb2JKYfQgHwZTsBmHKVl/9mBpv1y1+ygV+KNiiX/wWXWstLbdIo1jgPwZPbU2Vg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@solana/errors": "5.5.1",
-        "@solana/fast-stable-stringify": "5.5.1",
-        "@solana/functional": "5.5.1",
-        "@solana/rpc-api": "5.5.1",
-        "@solana/rpc-spec": "5.5.1",
-        "@solana/rpc-spec-types": "5.5.1",
-        "@solana/rpc-transformers": "5.5.1",
-        "@solana/rpc-transport-http": "5.5.1",
-        "@solana/rpc-types": "5.5.1"
+        "@solana/errors": "6.9.0",
+        "@solana/fast-stable-stringify": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/rpc-api": "6.9.0",
+        "@solana/rpc-spec": "6.9.0",
+        "@solana/rpc-spec-types": "6.9.0",
+        "@solana/rpc-transformers": "6.9.0",
+        "@solana/rpc-transport-http": "6.9.0",
+        "@solana/rpc-types": "6.9.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3504,29 +6312,30 @@
       }
     },
     "node_modules/@solana/rpc-api": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-5.5.1.tgz",
-      "integrity": "sha512-XWOQQPhKl06Vj0xi3RYHAc6oEQd8B82okYJ04K7N0Vvy3J4PN2cxeK7klwkjgavdcN9EVkYCChm2ADAtnztKnA==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-6.9.0.tgz",
+      "integrity": "sha512-3KhXS6A1ie6GqTywW/KEMSXJ1VJEU66fxjhuiiqPILuJstP7kex3ycr3H6DirKydUsy6gaKaPN43rE+LfyS7OA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/keys": "5.5.1",
-        "@solana/rpc-parsed-types": "5.5.1",
-        "@solana/rpc-spec": "5.5.1",
-        "@solana/rpc-transformers": "5.5.1",
-        "@solana/rpc-types": "5.5.1",
-        "@solana/transaction-messages": "5.5.1",
-        "@solana/transactions": "5.5.1"
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/rpc-parsed-types": "6.9.0",
+        "@solana/rpc-spec": "6.9.0",
+        "@solana/rpc-transformers": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/transaction-messages": "6.9.0",
+        "@solana/transactions": "6.9.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3534,17 +6343,379 @@
         }
       }
     },
-    "node_modules/@solana/rpc-parsed-types": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-5.5.1.tgz",
-      "integrity": "sha512-HEi3G2nZqGEsa3vX6U0FrXLaqnUCg4SKIUrOe8CezD+cSFbRTOn3rCLrUmJrhVyXlHoQVaRO9mmeovk31jWxJg==",
+    "node_modules/@solana/rpc-api/node_modules/@solana/addresses": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.9.0.tgz",
+      "integrity": "sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/assertions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.9.0.tgz",
+      "integrity": "sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/codecs-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
+      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/codecs-data-structures": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.9.0.tgz",
+      "integrity": "sha512-f7GYtiHafvJDhqiwzUUSr/6AYSK4DCw6quPmA80NZGtkNiFa+g6LoJy2wbC0wp2dxvCwNpxf6x3ILCYRutAvvg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/codecs-numbers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
+      "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/codecs-strings": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
+      "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/functional": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.9.0.tgz",
+      "integrity": "sha512-sgNHOaIjETZZuziZdlwPsU5EjBVj5M0dUbwrSQTTNZe0SxX3pQ1QFVcs5KyvdS7AQcpBVdLjx4CfQjdKXk52GA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/instructions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.9.0.tgz",
+      "integrity": "sha512-LZfJx3bGdUSbGaswoOEPHygticqkCg3TusRczPJXyCmKhoQzPCcGQQ99qMzP7Wg8pEV5tWA5t7tycf8E237ydg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/keys": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.9.0.tgz",
+      "integrity": "sha512-1g2QARiqSjNqT0EIqLDLQ5vRm7hCsbqgFwFAp5GsMV/8BTYT8s1Ct2wLHDZiJ4eAX6beTHVf8LbOBfVejtn3oQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/promises": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/nominal-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.9.0.tgz",
+      "integrity": "sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/rpc-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.9.0.tgz",
+      "integrity": "sha512-iFhPzZK3qiQ1lhfNTNBTI7BIs5PfWZSgRLD3enKm8ZAQggzvUklfO3KPh47jVsc/Jsr1UGPH8M3o3m17qjO1Cg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/fixed-points": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/transaction-messages": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.9.0.tgz",
+      "integrity": "sha512-OWpryt0w6SHlwHx12Vd1wvx2QwSGBXAIUEHTCtkctcM3AaZRy5cIl7CAq9iD5PgahUsaOyRLBV0zlCJcC2JrJA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/rpc-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/transactions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.9.0.tgz",
+      "integrity": "sha512-uKPzLwHbjwChfVl82he17ntkh02PfgnMMhN7uOAC+VbkIt1O+EEw8sX87gi6kdG/EV+QBDQXm9PLAo5W0tYylw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/transaction-messages": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@solana/rpc-parsed-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-6.9.0.tgz",
+      "integrity": "sha512-6ThH8izY+DWDyrVOOlS40vTcFjwjCinjfqnId7zhRk8OxhkfHQ/iEj+OnGwD4Yhe8pGdVa7GNVYlrQgQgzQ3eQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3553,20 +6724,21 @@
       }
     },
     "node_modules/@solana/rpc-spec": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-5.5.1.tgz",
-      "integrity": "sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-6.9.0.tgz",
+      "integrity": "sha512-3yHRoChc0IpsJbUq0/94l+ar3t9U3Ax58W0HON7eyYe7zFP10UAxpkHn7DPch9DeALyuGph8kVnvl+kXRgJlGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@solana/errors": "5.5.1",
-        "@solana/rpc-spec-types": "5.5.1"
+        "@solana/errors": "6.9.0",
+        "@solana/rpc-spec-types": "6.9.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3575,16 +6747,17 @@
       }
     },
     "node_modules/@solana/rpc-spec-types": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-5.5.1.tgz",
-      "integrity": "sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-6.9.0.tgz",
+      "integrity": "sha512-A4fY1JRrcKqX3EfttO4Q8L97nGPqdjfekAV0eDyxN5nu9ngf5p7GKenkl7AYDoHLNr6ZX/C96cRADxXjsRJ0iA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3592,30 +6765,68 @@
         }
       }
     },
-    "node_modules/@solana/rpc-subscriptions": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-5.5.1.tgz",
-      "integrity": "sha512-CTMy5bt/6mDh4tc6vUJms9EcuZj3xvK0/xq8IQ90rhkpYvate91RjBP+egvjgSayUg9yucU9vNuUpEjz4spM7w==",
+    "node_modules/@solana/rpc-spec/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@solana/errors": "5.5.1",
-        "@solana/fast-stable-stringify": "5.5.1",
-        "@solana/functional": "5.5.1",
-        "@solana/promises": "5.5.1",
-        "@solana/rpc-spec-types": "5.5.1",
-        "@solana/rpc-subscriptions-api": "5.5.1",
-        "@solana/rpc-subscriptions-channel-websocket": "5.5.1",
-        "@solana/rpc-subscriptions-spec": "5.5.1",
-        "@solana/rpc-transformers": "5.5.1",
-        "@solana/rpc-types": "5.5.1",
-        "@solana/subscribable": "5.5.1"
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-6.9.0.tgz",
+      "integrity": "sha512-IMctZQaMxzvRACQ6ooW98lP+7tVoUJnRgOZtkAdzgBizldQAYPIKd3MulP0jbQPCMfdPsa2Hs0NBcUwfgonq3w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0",
+        "@solana/fast-stable-stringify": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/promises": "6.9.0",
+        "@solana/rpc-spec-types": "6.9.0",
+        "@solana/rpc-subscriptions-api": "6.9.0",
+        "@solana/rpc-subscriptions-channel-websocket": "6.9.0",
+        "@solana/rpc-subscriptions-spec": "6.9.0",
+        "@solana/rpc-transformers": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/subscribable": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3624,25 +6835,26 @@
       }
     },
     "node_modules/@solana/rpc-subscriptions-api": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-5.5.1.tgz",
-      "integrity": "sha512-5Oi7k+GdeS8xR2ly1iuSFkAv6CZqwG0Z6b1QZKbEgxadE1XGSDrhM2cn59l+bqCozUWCqh4c/A2znU/qQjROlw==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-6.9.0.tgz",
+      "integrity": "sha512-UA/rPQeNx6zQMUFcS8PPPuB4vzUOtSzIY/igMH0DRoP020NyES2GguIb7Zo7sqDNi4n0gkQRhoW4dPVotcNKdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/keys": "5.5.1",
-        "@solana/rpc-subscriptions-spec": "5.5.1",
-        "@solana/rpc-transformers": "5.5.1",
-        "@solana/rpc-types": "5.5.1",
-        "@solana/transaction-messages": "5.5.1",
-        "@solana/transactions": "5.5.1"
+        "@solana/addresses": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/rpc-subscriptions-spec": "6.9.0",
+        "@solana/rpc-transformers": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/transaction-messages": "6.9.0",
+        "@solana/transactions": "6.9.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3650,73 +6862,754 @@
         }
       }
     },
-    "node_modules/@solana/rpc-subscriptions-channel-websocket": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-5.5.1.tgz",
-      "integrity": "sha512-7tGfBBrYY8TrngOyxSHoCU5shy86iA9SRMRrPSyBhEaZRAk6dnbdpmUTez7gtdVo0BCvh9nzQtUycKWSS7PnFQ==",
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/@solana/addresses": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.9.0.tgz",
+      "integrity": "sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@solana/errors": "5.5.1",
-        "@solana/functional": "5.5.1",
-        "@solana/rpc-subscriptions-spec": "5.5.1",
-        "@solana/subscribable": "5.5.1",
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/@solana/assertions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.9.0.tgz",
+      "integrity": "sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/@solana/codecs-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
+      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/@solana/codecs-data-structures": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.9.0.tgz",
+      "integrity": "sha512-f7GYtiHafvJDhqiwzUUSr/6AYSK4DCw6quPmA80NZGtkNiFa+g6LoJy2wbC0wp2dxvCwNpxf6x3ILCYRutAvvg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/@solana/codecs-numbers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
+      "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/@solana/codecs-strings": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
+      "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/@solana/functional": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.9.0.tgz",
+      "integrity": "sha512-sgNHOaIjETZZuziZdlwPsU5EjBVj5M0dUbwrSQTTNZe0SxX3pQ1QFVcs5KyvdS7AQcpBVdLjx4CfQjdKXk52GA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/@solana/instructions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.9.0.tgz",
+      "integrity": "sha512-LZfJx3bGdUSbGaswoOEPHygticqkCg3TusRczPJXyCmKhoQzPCcGQQ99qMzP7Wg8pEV5tWA5t7tycf8E237ydg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/@solana/keys": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.9.0.tgz",
+      "integrity": "sha512-1g2QARiqSjNqT0EIqLDLQ5vRm7hCsbqgFwFAp5GsMV/8BTYT8s1Ct2wLHDZiJ4eAX6beTHVf8LbOBfVejtn3oQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/promises": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/@solana/nominal-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.9.0.tgz",
+      "integrity": "sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/@solana/rpc-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.9.0.tgz",
+      "integrity": "sha512-iFhPzZK3qiQ1lhfNTNBTI7BIs5PfWZSgRLD3enKm8ZAQggzvUklfO3KPh47jVsc/Jsr1UGPH8M3o3m17qjO1Cg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/fixed-points": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/@solana/transaction-messages": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.9.0.tgz",
+      "integrity": "sha512-OWpryt0w6SHlwHx12Vd1wvx2QwSGBXAIUEHTCtkctcM3AaZRy5cIl7CAq9iD5PgahUsaOyRLBV0zlCJcC2JrJA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/rpc-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/@solana/transactions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.9.0.tgz",
+      "integrity": "sha512-uKPzLwHbjwChfVl82he17ntkh02PfgnMMhN7uOAC+VbkIt1O+EEw8sX87gi6kdG/EV+QBDQXm9PLAo5W0tYylw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/transaction-messages": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-6.9.0.tgz",
+      "integrity": "sha512-kT8Yne9HjJD2gooaOFNSyKrvaIfOy2GR0Ymv8OfecBCwFStdz+SPo5eYXq8ZWoZbr5E/MMpHgqsHBanqa2Ffyg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/rpc-subscriptions-spec": "6.9.0",
+        "@solana/subscribable": "6.9.0",
         "ws": "^8.19.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket/node_modules/@solana/functional": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.9.0.tgz",
+      "integrity": "sha512-sgNHOaIjETZZuziZdlwPsU5EjBVj5M0dUbwrSQTTNZe0SxX3pQ1QFVcs5KyvdS7AQcpBVdLjx4CfQjdKXk52GA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@solana/rpc-subscriptions-spec": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-5.5.1.tgz",
-      "integrity": "sha512-iq+rGq5fMKP3/mKHPNB6MC8IbVW41KGZg83Us/+LE3AWOTWV1WT20KT2iH1F1ik9roi42COv/TpoZZvhKj45XQ==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-6.9.0.tgz",
+      "integrity": "sha512-DbaG67s99vRZQxFMK80UQ7DEKkRJK6JEZeYg/U5UttD6n7ax/vct7qopxGnrt4RCkaaac2fU8Sr+fcnvWQweUg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@solana/errors": "5.5.1",
-        "@solana/promises": "5.5.1",
-        "@solana/rpc-spec-types": "5.5.1",
-        "@solana/subscribable": "5.5.1"
+        "@solana/errors": "6.9.0",
+        "@solana/promises": "6.9.0",
+        "@solana/rpc-spec-types": "6.9.0",
+        "@solana/subscribable": "6.9.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/@solana/addresses": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.9.0.tgz",
+      "integrity": "sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/@solana/assertions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.9.0.tgz",
+      "integrity": "sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/@solana/codecs-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
+      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/@solana/codecs-numbers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
+      "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/@solana/codecs-strings": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
+      "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/@solana/functional": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.9.0.tgz",
+      "integrity": "sha512-sgNHOaIjETZZuziZdlwPsU5EjBVj5M0dUbwrSQTTNZe0SxX3pQ1QFVcs5KyvdS7AQcpBVdLjx4CfQjdKXk52GA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/@solana/nominal-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.9.0.tgz",
+      "integrity": "sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/@solana/rpc-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.9.0.tgz",
+      "integrity": "sha512-iFhPzZK3qiQ1lhfNTNBTI7BIs5PfWZSgRLD3enKm8ZAQggzvUklfO3KPh47jVsc/Jsr1UGPH8M3o3m17qjO1Cg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/fixed-points": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@solana/rpc-transformers": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-5.5.1.tgz",
-      "integrity": "sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-6.9.0.tgz",
+      "integrity": "sha512-dg4LK2wEBpaY+KRk/SJIkYvrvjdsc1AwD4bkmGY4Fp7EwVlvwBQShAQn78Qi4IP0WQ/0n9ncFyUxgcB1Y01ZuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@solana/errors": "5.5.1",
-        "@solana/functional": "5.5.1",
-        "@solana/nominal-types": "5.5.1",
-        "@solana/rpc-spec-types": "5.5.1",
-        "@solana/rpc-types": "5.5.1"
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/rpc-spec-types": "6.9.0",
+        "@solana/rpc-types": "6.9.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3724,28 +7617,290 @@
         }
       }
     },
-    "node_modules/@solana/rpc-transport-http": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-5.5.1.tgz",
-      "integrity": "sha512-yv8GoVSHqEV0kUJEIhkdOVkR2SvJ6yoWC51cJn2rSV7plr6huLGe0JgujCmB7uZhhaLbcbP3zxXxu9sOjsi7Fg==",
+    "node_modules/@solana/rpc-transformers/node_modules/@solana/addresses": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.9.0.tgz",
+      "integrity": "sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@solana/errors": "5.5.1",
-        "@solana/rpc-spec": "5.5.1",
-        "@solana/rpc-spec-types": "5.5.1",
-        "undici-types": "^7.19.2"
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/@solana/assertions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.9.0.tgz",
+      "integrity": "sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/@solana/codecs-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
+      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/@solana/codecs-numbers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
+      "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/@solana/codecs-strings": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
+      "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/@solana/functional": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.9.0.tgz",
+      "integrity": "sha512-sgNHOaIjETZZuziZdlwPsU5EjBVj5M0dUbwrSQTTNZe0SxX3pQ1QFVcs5KyvdS7AQcpBVdLjx4CfQjdKXk52GA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/@solana/nominal-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.9.0.tgz",
+      "integrity": "sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/@solana/rpc-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.9.0.tgz",
+      "integrity": "sha512-iFhPzZK3qiQ1lhfNTNBTI7BIs5PfWZSgRLD3enKm8ZAQggzvUklfO3KPh47jVsc/Jsr1UGPH8M3o3m17qjO1Cg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/fixed-points": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@solana/rpc-transport-http": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-6.9.0.tgz",
+      "integrity": "sha512-4gy30fWJcS6jrcXCoP/optFpGJ/gD9xdkE8wDbe1Ys/Y+e4XjyBt45xtTnbdmMdukvdRX+oXS3zgUIYoagpNzQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0",
+        "@solana/rpc-spec": "6.9.0",
+        "@solana/rpc-spec-types": "6.9.0",
+        "undici-types": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@solana/rpc-types": {
@@ -3774,33 +7929,619 @@
         }
       }
     },
-    "node_modules/@solana/signers": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-5.5.1.tgz",
-      "integrity": "sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ==",
+    "node_modules/@solana/rpc/node_modules/@solana/addresses": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.9.0.tgz",
+      "integrity": "sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/codecs-core": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/instructions": "5.5.1",
-        "@solana/keys": "5.5.1",
-        "@solana/nominal-types": "5.5.1",
-        "@solana/offchain-messages": "5.5.1",
-        "@solana/transaction-messages": "5.5.1",
-        "@solana/transactions": "5.5.1"
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/@solana/assertions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.9.0.tgz",
+      "integrity": "sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/@solana/codecs-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
+      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/@solana/codecs-numbers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
+      "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/@solana/codecs-strings": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
+      "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/@solana/functional": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.9.0.tgz",
+      "integrity": "sha512-sgNHOaIjETZZuziZdlwPsU5EjBVj5M0dUbwrSQTTNZe0SxX3pQ1QFVcs5KyvdS7AQcpBVdLjx4CfQjdKXk52GA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/@solana/nominal-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.9.0.tgz",
+      "integrity": "sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/@solana/rpc-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.9.0.tgz",
+      "integrity": "sha512-iFhPzZK3qiQ1lhfNTNBTI7BIs5PfWZSgRLD3enKm8ZAQggzvUklfO3KPh47jVsc/Jsr1UGPH8M3o3m17qjO1Cg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/fixed-points": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@solana/signers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-6.9.0.tgz",
+      "integrity": "sha512-x7WyoRm9IORMqeSqNivZgyY+RERPkmqWxpINPD13kUH+oaZzonORIgxk2Lz+u5iPRXiJPkdRPrQ4FoFWv8i6kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/offchain-messages": "6.9.0",
+        "@solana/transaction-messages": "6.9.0",
+        "@solana/transactions": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/addresses": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.9.0.tgz",
+      "integrity": "sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/assertions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.9.0.tgz",
+      "integrity": "sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/codecs-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
+      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/codecs-data-structures": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.9.0.tgz",
+      "integrity": "sha512-f7GYtiHafvJDhqiwzUUSr/6AYSK4DCw6quPmA80NZGtkNiFa+g6LoJy2wbC0wp2dxvCwNpxf6x3ILCYRutAvvg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/codecs-numbers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
+      "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/codecs-strings": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
+      "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/functional": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.9.0.tgz",
+      "integrity": "sha512-sgNHOaIjETZZuziZdlwPsU5EjBVj5M0dUbwrSQTTNZe0SxX3pQ1QFVcs5KyvdS7AQcpBVdLjx4CfQjdKXk52GA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/instructions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.9.0.tgz",
+      "integrity": "sha512-LZfJx3bGdUSbGaswoOEPHygticqkCg3TusRczPJXyCmKhoQzPCcGQQ99qMzP7Wg8pEV5tWA5t7tycf8E237ydg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/keys": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.9.0.tgz",
+      "integrity": "sha512-1g2QARiqSjNqT0EIqLDLQ5vRm7hCsbqgFwFAp5GsMV/8BTYT8s1Ct2wLHDZiJ4eAX6beTHVf8LbOBfVejtn3oQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/promises": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/nominal-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.9.0.tgz",
+      "integrity": "sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/rpc-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.9.0.tgz",
+      "integrity": "sha512-iFhPzZK3qiQ1lhfNTNBTI7BIs5PfWZSgRLD3enKm8ZAQggzvUklfO3KPh47jVsc/Jsr1UGPH8M3o3m17qjO1Cg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/fixed-points": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/transaction-messages": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.9.0.tgz",
+      "integrity": "sha512-OWpryt0w6SHlwHx12Vd1wvx2QwSGBXAIUEHTCtkctcM3AaZRy5cIl7CAq9iD5PgahUsaOyRLBV0zlCJcC2JrJA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/rpc-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/transactions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.9.0.tgz",
+      "integrity": "sha512-uKPzLwHbjwChfVl82he17ntkh02PfgnMMhN7uOAC+VbkIt1O+EEw8sX87gi6kdG/EV+QBDQXm9PLAo5W0tYylw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/transaction-messages": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@solana/spl-token": {
@@ -4074,43 +8815,84 @@
       }
     },
     "node_modules/@solana/subscribable": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-5.5.1.tgz",
-      "integrity": "sha512-9K0PsynFq0CsmK1CDi5Y2vUIJpCqkgSS5yfDN0eKPgHqEptLEaia09Kaxc90cSZDZU5mKY/zv1NBmB6Aro9zQQ==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-6.9.0.tgz",
+      "integrity": "sha512-YV0/BrJNfepf10CTfLwD7kRY1kkELDHd+BbHJZhBeiuiXTY3xQTvvx1RFs3NtfFCcTHG25Uh8NpRacQJnxSSIQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@solana/errors": "5.5.1"
+        "@solana/errors": "6.9.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/subscribable/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/subscribable/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@solana/sysvars": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-5.5.1.tgz",
-      "integrity": "sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-6.9.0.tgz",
+      "integrity": "sha512-e0e+QKr/th9t/O2N1oUoJmcodLghzAtWKUlGb1zyYub0/WJrPImnKqJqp/gDP4tK98mJxopPMcprCeHk4B+TQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@solana/accounts": "5.5.1",
-        "@solana/codecs": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/rpc-types": "5.5.1"
+        "@solana/accounts": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/rpc-types": "6.9.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -4118,34 +8900,625 @@
         }
       }
     },
-    "node_modules/@solana/transaction-confirmation": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-5.5.1.tgz",
-      "integrity": "sha512-j4mKlYPHEyu+OD7MBt3jRoX4ScFgkhZC6H65on4Fux6LMScgivPJlwnKoZMnsgxFgWds0pl+BYzSiALDsXlYtw==",
+    "node_modules/@solana/sysvars/node_modules/@solana/addresses": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.9.0.tgz",
+      "integrity": "sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/keys": "5.5.1",
-        "@solana/promises": "5.5.1",
-        "@solana/rpc": "5.5.1",
-        "@solana/rpc-subscriptions": "5.5.1",
-        "@solana/rpc-types": "5.5.1",
-        "@solana/transaction-messages": "5.5.1",
-        "@solana/transactions": "5.5.1"
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/assertions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.9.0.tgz",
+      "integrity": "sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/codecs-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
+      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/codecs-data-structures": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.9.0.tgz",
+      "integrity": "sha512-f7GYtiHafvJDhqiwzUUSr/6AYSK4DCw6quPmA80NZGtkNiFa+g6LoJy2wbC0wp2dxvCwNpxf6x3ILCYRutAvvg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/codecs-numbers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
+      "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/codecs-strings": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
+      "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/nominal-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.9.0.tgz",
+      "integrity": "sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/rpc-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.9.0.tgz",
+      "integrity": "sha512-iFhPzZK3qiQ1lhfNTNBTI7BIs5PfWZSgRLD3enKm8ZAQggzvUklfO3KPh47jVsc/Jsr1UGPH8M3o3m17qjO1Cg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/fixed-points": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@solana/transaction-confirmation": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-6.9.0.tgz",
+      "integrity": "sha512-fzYCOih7hhtBzzNSkAnxMjeFeQ8U7e27k9i0RsgQc3/e3OCynF5HoIVNhhqZbwfIBKiaD4ginJR6slRnfqO32Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/promises": "6.9.0",
+        "@solana/rpc": "6.9.0",
+        "@solana/rpc-subscriptions": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/transaction-messages": "6.9.0",
+        "@solana/transactions": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/addresses": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.9.0.tgz",
+      "integrity": "sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/assertions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.9.0.tgz",
+      "integrity": "sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/codecs-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
+      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/codecs-data-structures": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.9.0.tgz",
+      "integrity": "sha512-f7GYtiHafvJDhqiwzUUSr/6AYSK4DCw6quPmA80NZGtkNiFa+g6LoJy2wbC0wp2dxvCwNpxf6x3ILCYRutAvvg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/codecs-numbers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
+      "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/codecs-strings": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
+      "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/functional": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.9.0.tgz",
+      "integrity": "sha512-sgNHOaIjETZZuziZdlwPsU5EjBVj5M0dUbwrSQTTNZe0SxX3pQ1QFVcs5KyvdS7AQcpBVdLjx4CfQjdKXk52GA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/instructions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.9.0.tgz",
+      "integrity": "sha512-LZfJx3bGdUSbGaswoOEPHygticqkCg3TusRczPJXyCmKhoQzPCcGQQ99qMzP7Wg8pEV5tWA5t7tycf8E237ydg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/keys": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.9.0.tgz",
+      "integrity": "sha512-1g2QARiqSjNqT0EIqLDLQ5vRm7hCsbqgFwFAp5GsMV/8BTYT8s1Ct2wLHDZiJ4eAX6beTHVf8LbOBfVejtn3oQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/promises": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/nominal-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.9.0.tgz",
+      "integrity": "sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/rpc-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.9.0.tgz",
+      "integrity": "sha512-iFhPzZK3qiQ1lhfNTNBTI7BIs5PfWZSgRLD3enKm8ZAQggzvUklfO3KPh47jVsc/Jsr1UGPH8M3o3m17qjO1Cg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/fixed-points": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/transaction-messages": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.9.0.tgz",
+      "integrity": "sha512-OWpryt0w6SHlwHx12Vd1wvx2QwSGBXAIUEHTCtkctcM3AaZRy5cIl7CAq9iD5PgahUsaOyRLBV0zlCJcC2JrJA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/rpc-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/transactions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.9.0.tgz",
+      "integrity": "sha512-uKPzLwHbjwChfVl82he17ntkh02PfgnMMhN7uOAC+VbkIt1O+EEw8sX87gi6kdG/EV+QBDQXm9PLAo5W0tYylw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/transaction-messages": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@solana/transaction-messages": {
@@ -5556,16 +10929,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/console-table-printer": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.16.0.tgz",
-      "integrity": "sha512-X46F33vlP/jVYT3ajukzmOea4Bxet/jRjBKY/fhqr0IvTUNdfBYlrh+Juk0eiZJaTJYrzlEd4RFMF5cQac+m/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "simple-wcswidth": "^1.1.2"
       }
     },
     "node_modules/cookie": {
@@ -7079,16 +12442,6 @@
       "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
       "license": "MIT"
     },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -7936,17 +13289,6 @@
         "node": ">=6.14.2"
       }
     },
-    "node_modules/jayson/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.11",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
@@ -8072,10 +13414,10 @@
         "@langchain/core": "^1.1.48"
       }
     },
-    "node_modules/langsmith": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.4.tgz",
-      "integrity": "sha512-EGYCw85etSarYazeTgj8DICVIFg+26gsVZ0zq8V7kjIb59huURJpZZJqVFkvRpZFxmfyYrpIhtk2qtHgGR8K+w==",
+    "node_modules/langchain/node_modules/langsmith": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.6.3.tgz",
+      "integrity": "sha512-pXrQ4/4myQvjFFOAUmt5pWRrLEZR20gzIJD7MNdUH+5/S5nLI4ZRBo/SYKC6coaYj9pYTfQdBIzcs+3kfJ5uDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10839,13 +16181,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/simple-wcswidth": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
-      "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -11089,19 +16424,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/svgo": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
@@ -11329,11 +16651,12 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.27.0.tgz",
-      "integrity": "sha512-sqqlwW3zm+cE82GwKdGyn3pcze7LXlx/4jUgA0vtAf6Fa81KMrJqc3VfWmmeOTUIElW9IdPsLwMUIpiOZQgK3A==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.4.1.tgz",
+      "integrity": "sha512-iIXDNrTeaM0lDZvNUY1Urfs9dVgOWdQCkv6VMiePh644EKce0qoz6FNxxg7/DS4CxbFI36Atlz0VgHKS2qL1Dw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/package.json
+++ b/package.json
@@ -23,9 +23,13 @@
     "sharp": "^0.34.2"
   },
   "devDependencies": {
-    "@sip-protocol/sdk": "^0.9.0",
+    "@sip-protocol/sdk": "^0.11.1",
     "@sip-protocol/types": "^0.2.1",
     "typedoc": "^0.28.16",
     "typedoc-plugin-markdown": "^4.4.0"
+  },
+  "overrides": {
+    "langsmith": "^0.6.0",
+    "uuid": "^14.0.0"
   }
 }


### PR DESCRIPTION
## Summary

Clears the 7 open Dependabot alerts on this repo. All 7 are **development-scope transitive** deps under the `@sip-protocol/sdk` devDependency, which this repo consumes only through TypeDoc (`dist/index.d.ts` — no SDK code executes in the build or ships to the site).

**5 fixed in-tree, 2 recommended for dismissal** (both have no patched release — full evidence in `docs/security/DEPENDENCY-AUDIT.md`).

| Alert | Package | Sev | Disposition |
|-------|---------|-----|-------------|
| #64 | langsmith < 0.6.0 | high | Fixed — override → 0.6.3 |
| #63 | langsmith <= 0.5.18 | med | Fixed — override → 0.6.3 |
| #62 | langsmith <= 0.5.17 | med | Fixed — override → 0.6.3 |
| #61 | langsmith < 0.4.6 | med | Fixed — override → 0.6.3 |
| #58 | uuid < 11.1.1 | med | Fixed — override → 14.0.0 (prod `mermaid` already on 14.0.0, unchanged) |
| #3 | bigint-buffer <= 1.1.5 | high | Recommend dismiss `not_used` — no patch; see below |
| #60 | elliptic <= 6.6.1 | low | Recommend dismiss `not_used` — no patch; signing-only flaw, verify-only consumer |

## Changes

- `@sip-protocol/sdk` `^0.9.0` → `^0.11.1` (latest; typedoc-only usage, so the 0.10.x breaking stealth-API changes don't affect this repo — API reference now documents the current SDK: 1,284 pages vs 1,277)
- npm `overrides`: `langsmith ^0.6.0`, `uuid ^14.0.0` (the SDK bump alone can't clear langsmith — SDK 0.11.1 still pins `@langchain/core ^0.3.30` whose langsmith range is capped inside the vulnerable window)
- `docs/security/DEPENDENCY-AUDIT.md` — disposition table, consumer chains, dismissal evidence (kept out of `src/content`, so nothing is published)

## Why not the bigint-buffer-fixed alias

The fork alias used in the core repo was tried and **reverted**: `bigint-buffer-fixed@1.1.6` declares `node-gyp@^9.4.1` as a runtime dep, which pulled `node-gyp 9.4.1` / `tar 6.2.1` / `cacache 16.1.3` / `make-fetch-happen 10.2.1` into the lockfile — four packages with current high-severity advisories (incl. the node-tar path-traversal set affecting <= 7.5.10), with node-gyp executing on every `npm ci`. Trading one unreachable HIGH for four new HIGHs is net-negative, so the honest disposition is dismissal (heads-up: the core repo's pnpm lockfile may now have the same stale tar chain).

## Verification

- Baseline (main): fresh `npm ci` + `npm run build` green (1,277 pages)
- After: fresh `npm ci` + `npm run build` green (1,284 pages)
- Lockfile census: langsmith 0.6.3 ×3, uuid 14.0.0 ×1 (single prod node), no vulnerable nodes remain besides the two unpatchable ones above
- Lockfile regenerated with `npx npm@10 install` (CI runs Node 22 / npm 10 — npm 11 lockfiles break npm 10 `npm ci` on optional deps); policy recorded in the audit doc

## Supersedes

This PR includes the `@sip-protocol/sdk` bump to the latest 0.11.1, so it **supersedes #113 (0.11.0), #114 (Dependabot 0.9.0→0.11.0), and #115 (0.11.1)** — leaving those open for the maintainer to close once this merges.

**Note:** alerts #3 and #60 are *not* dismissed by this PR — dismissal via the Dependabot UI/API is left to the maintainer, with the evidence prepared in the audit doc.